### PR TITLE
Relax commitlint body and footer line length rules

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always', Infinity],
+    'footer-max-line-length': [0, 'always', Infinity],
+  },
 };


### PR DESCRIPTION
This PR updates the commitlint configuration to disable the 'body-max-line-length' and 'footer-max-line-length' rules. This is necessary to accommodate long URLs and automated metadata in commit messages, especially those generated by Dependabot, which were causing CI failures.

---
*PR created automatically by Jules for task [17663939788811038573](https://jules.google.com/task/17663939788811038573) started by @d-oit*