### PR TITLE
perf/ui: Implement LOD and mutation batching for Sigma.js graph

### DIFF
--- a/src/features/graph/GraphView.tsx
+++ b/src/features/graph/GraphView.tsx
@@ -32,10 +32,50 @@ const GraphView: React.FC<Props> = ({ entities, links }) => {
     };
   }, [entities, links, selectedNode, focusMode]);
 
+  const graph = useMemo(() => new Graph(), []);
+
+  // Initialize Sigma
   useEffect(() => {
     if (!containerRef.current) return;
 
-    const graph = new Graph();
+    if (!sigmaInstance.current) {
+      sigmaInstance.current = new Sigma(graph, containerRef.current, {
+        renderEdgeLabels: true,
+        defaultEdgeType: 'arrow',
+        labelRenderedSizeThreshold: 10
+      });
+
+      const camera = sigmaInstance.current.getCamera();
+      camera.on('updated', () => {
+        const ratio = camera.ratio;
+        // LOD: Hide edge labels when zoomed out (ratio > 2)
+        const shouldRenderEdgeLabels = ratio < 2;
+        if (sigmaInstance.current && sigmaInstance.current.getSetting('renderEdgeLabels') !== shouldRenderEdgeLabels) {
+          sigmaInstance.current.setSetting('renderEdgeLabels', shouldRenderEdgeLabels);
+        }
+      });
+
+      sigmaInstance.current.on('clickNode', ({ node }) => {
+        setSelectedNode(node);
+      });
+
+      sigmaInstance.current.on('clickStage', () => {
+        setSelectedNode(null);
+        setFocusMode(false);
+      });
+    }
+
+    return () => {
+      if (sigmaInstance.current) {
+        sigmaInstance.current.kill();
+        sigmaInstance.current = null;
+      }
+    };
+  }, [graph]);
+
+  // Update Graph Data
+  useEffect(() => {
+    graph.clear();
 
     if (filteredData.entities.length === 0 && !focusMode) {
       // Show default placeholder if no data
@@ -61,29 +101,23 @@ const GraphView: React.FC<Props> = ({ entities, links }) => {
       });
     }
 
-    if (sigmaInstance.current) {
-        sigmaInstance.current.kill();
-    }
+    sigmaInstance.current?.refresh();
+  }, [graph, filteredData, selectedNode, focusMode]);
 
-    sigmaInstance.current = new Sigma(graph, containerRef.current, {
-      renderEdgeLabels: true,
-      defaultEdgeType: 'arrow'
+  // Handle Resizing
+  useEffect(() => {
+    if (!containerRef.current || !sigmaInstance.current) return;
+
+    const observer = new ResizeObserver(() => {
+      sigmaInstance.current?.refresh();
     });
 
-    sigmaInstance.current.on('clickNode', ({ node }) => {
-      setSelectedNode(node);
-    });
-
-    sigmaInstance.current.on('clickStage', () => {
-      setSelectedNode(null);
-      setFocusMode(false);
-    });
+    observer.observe(containerRef.current);
 
     return () => {
-      sigmaInstance.current?.kill();
-      sigmaInstance.current = null;
+      observer.disconnect();
     };
-  }, [filteredData, selectedNode, focusMode]);
+  }, []);
 
   return (
     <div className="graph-container">


### PR DESCRIPTION
This PR optimizes the Sigma.js knowledge graph performance and responsiveness. 

Key changes:
- **Mutation Batching**: Refactored `GraphView.tsx` to maintain a persistent `Graph` instance (via `useMemo`) and a `Sigma` instance (via `useRef`). Instead of killing and recreating the entire Sigma instance on every data change, we now clear and repopulate the `graphology` instance and call `.refresh()`. This avoids expensive WebGL context re-creations.
- **Level-of-Detail (LOD)**: Configured `labelRenderedSizeThreshold` to hide node labels when zoomed out. Added a camera listener to dynamically toggle `renderEdgeLabels` based on the zoom ratio, improving frame rates in dense graphs.
- **Responsive Canvas**: Replaced fixed height/width with a `ResizeObserver` that triggers a graph refresh when the container dimensions change, ensuring the canvas accurately resizes across different device orientations and layouts.

Fixes #31

---
*PR created automatically by Jules for task [8595205857689686676](https://jules.google.com/task/8595205857689686676) started by @d-oit*