### PR TITLE
Make graph and mind map opt-in secondary views with render budgets

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,6 +12,7 @@ import MobileDrawer from '../components/MobileDrawer';
 import SearchPanel from '../features/search/SearchPanel';
 import { RankedResult } from '../lib/search';
 import { GraphControls } from '../features/graph/GraphControls';
+import JobMetrics from '../components/JobMetrics';
 
 const Editor = lazy(() => import('../features/editor/Editor'));
 const GraphView = lazy(() => import('../features/graph/GraphView'));
@@ -64,7 +65,7 @@ const AppContent: React.FC = () => {
   }, [dbReady, refreshData]);
 
   useEffect(() => {
-    if (dbReady) {
+    if (dbReady && (currentView === 'graph' || currentView === 'mindmap')) {
       refreshData();
     }
   }, [currentView, dbReady, refreshData]);
@@ -101,7 +102,7 @@ const AppContent: React.FC = () => {
             {dbReady && currentView === 'mindmap' && entities.length > 0 && (
               <MindMapView
                 rootEntity={entities[0]}
-                relatedEntities={entities.slice(1, 10)}
+                relatedEntities={entities.slice(1, 100)}
               />
             )}
             {dbReady && currentView === 'mindmap' && entities.length === 0 && (
@@ -146,6 +147,8 @@ const AppContent: React.FC = () => {
           />
         </div>
       )}
+
+      {import.meta.env.DEV && <JobMetrics />}
     </div>
   );
 };

--- a/src/components/JobMetrics.tsx
+++ b/src/components/JobMetrics.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { jobCoordinator, JobMetrics as Metrics } from '../lib/jobs';
+
+const JobMetrics: React.FC = () => {
+  const [metrics, setMetrics] = useState<Metrics>(jobCoordinator.getMetrics());
+  const renderCount = useRef(0);
+  renderCount.current++;
+
+  useEffect(() => {
+    return jobCoordinator.subscribe(setMetrics);
+  }, []);
+
+  if (process.env.NODE_ENV === 'production' && !import.meta.env?.DEV) return null;
+
+  return (
+    <div className="job-metrics-panel" style={{
+      position: 'fixed',
+      bottom: '1rem',
+      right: '1rem',
+      background: 'rgba(0,0,0,0.8)',
+      color: '#fff',
+      padding: '0.75rem',
+      borderRadius: '8px',
+      fontSize: '0.75rem',
+      zIndex: 9999,
+      fontFamily: 'monospace',
+      pointerEvents: 'none'
+    }}>
+      <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', borderBottom: '1px solid #444' }}>
+        Background Jobs
+      </div>
+      <div>Queued: {metrics.queued}</div>
+      <div>Running: {metrics.running}</div>
+      <div>Completed: {metrics.completed}</div>
+      <div>Failed: {metrics.failed}</div>
+      <div>Cancelled: {metrics.cancelled}</div>
+      <div>Coalesced: {metrics.coalesced}</div>
+      <div>Avg Execution: {metrics.completed > 0 ? (metrics.totalExecutionTime / metrics.completed).toFixed(2) : 0}ms</div>
+      <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid #444' }}>
+        UI Renders: {renderCount.current}
+      </div>
+    </div>
+  );
+};
+
+export default JobMetrics;

--- a/src/features/graph/GraphView.tsx
+++ b/src/features/graph/GraphView.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import Sigma from 'sigma';
 import Graph from 'graphology';
 import { Entity, Link } from '../../lib/validation';
 import { GraphControls } from './GraphControls';
+import { jobCoordinator } from '../../lib/jobs';
+import { logger } from '../../lib/logger';
 
 interface Props {
   entities: Entity[];
@@ -13,6 +15,9 @@ interface Props {
   onSelectedNodeChange?: (nodeId: string | null) => void;
   hideToolbar?: boolean;
 }
+
+const MAX_NODES = 200;
+const MAX_EDGES = 500;
 
 const GraphView: React.FC<Props> = ({
   entities,
@@ -25,12 +30,18 @@ const GraphView: React.FC<Props> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const sigmaInstance = useRef<Sigma | null>(null);
+  const [isActive, setIsActive] = useState(false);
+  const [isComputing, setIsComputing] = useState(false);
+  const [budgetExceeded, setBudgetExceeded] = useState(false);
+  const [stats, setStats] = useState({ nodes: 0, edges: 0 });
 
   const [internalSelectedNode, setInternalSelectedNode] = useState<string | null>(null);
   const [internalFocusMode, setInternalFocusMode] = useState(false);
 
   const selectedNode = propsSelectedNode !== undefined ? propsSelectedNode : internalSelectedNode;
   const focusMode = propsFocusMode !== undefined ? propsFocusMode : internalFocusMode;
+
+  const [filteredData, setFilteredData] = useState<{ entities: Entity[]; links: Link[] }>({ entities: [], links: [] });
 
   const setSelectedNode = useCallback((node: string | null) => {
     if (onSelectedNodeChange) onSelectedNodeChange(node);
@@ -42,25 +53,70 @@ const GraphView: React.FC<Props> = ({
     else setInternalFocusMode(focus);
   }, [onFocusModeChange]);
 
-  const filteredData = useMemo(() => {
-    if (!focusMode || !selectedNode) {
-      return { entities, links };
-    }
+  // Offload neighborhood computation to JobCoordinator
+  useEffect(() => {
+    if (!isActive) return;
 
-    const neighborIds = new Set<string>([selectedNode]);
-    links.forEach(l => {
-      if (l.source_id === selectedNode) neighborIds.add(l.target_id);
-      if (l.target_id === selectedNode) neighborIds.add(l.source_id);
+    setIsComputing(true);
+    jobCoordinator.enqueue({
+      id: `graph-recompute-${Date.now()}`,
+      type: 'recompute-neighborhood',
+      payload: { entities, links, selectedNode, focusMode },
+      coalesceKey: 'graph-recompute',
+      execute: async (signal) => {
+        // Simulate some work or just yield to main thread
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        if (signal.aborted) throw new Error('AbortError');
+
+        let resultEntities = entities;
+        let resultLinks = links;
+
+        if (focusMode && selectedNode) {
+          const neighborIds = new Set<string>([selectedNode]);
+          links.forEach(l => {
+            if (l.source_id === selectedNode) neighborIds.add(l.target_id);
+            if (l.target_id === selectedNode) neighborIds.add(l.source_id);
+          });
+
+          resultEntities = entities.filter(e => neighborIds.has(e.id!));
+          resultLinks = links.filter(l => neighborIds.has(l.source_id) && neighborIds.has(l.target_id));
+        }
+
+        const isExceeded = resultEntities.length > MAX_NODES || resultLinks.length > MAX_EDGES;
+
+        // Ensure selectedNode is always included if it exists in original data
+        let finalEntities = resultEntities.slice(0, MAX_NODES);
+        if (selectedNode && !finalEntities.find(e => e.id === selectedNode)) {
+            const selected = resultEntities.find(e => e.id === selectedNode);
+            if (selected) {
+                finalEntities = [selected, ...resultEntities.filter(e => e.id !== selectedNode).slice(0, MAX_NODES - 1)];
+            }
+        }
+
+        return {
+          entities: finalEntities,
+          links: resultLinks.slice(0, MAX_EDGES),
+          budgetExceeded: isExceeded,
+          totalNodes: resultEntities.length,
+          totalEdges: resultLinks.length
+        };
+      },
+      onComplete: (result) => {
+        setFilteredData({ entities: result.entities, links: result.links });
+        setBudgetExceeded(result.budgetExceeded);
+        setStats({ nodes: result.totalNodes, edges: result.totalEdges });
+        setIsComputing(false);
+      },
+      onError: (err) => {
+        logger.error('Graph computation failed', err);
+        setIsComputing(false);
+      }
     });
-
-    return {
-      entities: entities.filter(e => neighborIds.has(e.id!)),
-      links: links.filter(l => neighborIds.has(l.source_id) && neighborIds.has(l.target_id))
-    };
-  }, [entities, links, selectedNode, focusMode]);
+  }, [isActive, entities, links, selectedNode, focusMode]);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current || !isActive) return;
 
     const graph = new Graph();
 
@@ -69,17 +125,19 @@ const GraphView: React.FC<Props> = ({
       graph.addNode('1', { label: 'Knowledge Studio', size: 10, color: '#2563eb', x: 0, y: 0 });
     } else {
       filteredData.entities.forEach((e, i) => {
-        graph.addNode(e.id ?? String(i), {
-          label: e.name,
-          size: e.id === selectedNode ? 20 : 10,
-          color: e.id === selectedNode ? '#ef4444' : '#2563eb',
-          x: Math.cos((i * 2 * Math.PI) / filteredData.entities.length),
-          y: Math.sin((i * 2 * Math.PI) / filteredData.entities.length)
-        });
+        if (!graph.hasNode(e.id!)) {
+            graph.addNode(e.id ?? String(i), {
+              label: e.name,
+              size: e.id === selectedNode ? 20 : 10,
+              color: e.id === selectedNode ? '#ef4444' : '#2563eb',
+              x: Math.cos((i * 2 * Math.PI) / filteredData.entities.length),
+              y: Math.sin((i * 2 * Math.PI) / filteredData.entities.length)
+            });
+        }
       });
       filteredData.links.forEach((l) => {
         if (graph.hasNode(l.source_id) && graph.hasNode(l.target_id)) {
-          graph.addEdge(l.source_id, l.target_id, {
+          graph.mergeEdge(l.source_id, l.target_id, {
             label: l.relation,
             size: 2,
             color: '#94a3b8'
@@ -110,7 +168,26 @@ const GraphView: React.FC<Props> = ({
       sigmaInstance.current?.kill();
       sigmaInstance.current = null;
     };
-  }, [filteredData, selectedNode, focusMode, setFocusMode, setSelectedNode]);
+  }, [isActive, filteredData, selectedNode, focusMode, setFocusMode, setSelectedNode]);
+
+  if (!isActive) {
+    return (
+      <div className="graph-container cold-state" style={{
+        height: '600px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        background: 'var(--bg-secondary)',
+        borderRadius: '8px'
+      }}>
+        <p>Knowledge Graph is currently inactive to save resources.</p>
+        <button className="btn-primary" onClick={() => setIsActive(true)}>
+          Activate Graph View
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="graph-container">
@@ -122,6 +199,12 @@ const GraphView: React.FC<Props> = ({
             hasSelection={!!selectedNode}
             selectedName={entities.find(e => e.id === selectedNode)?.name}
           />
+          {isComputing && <span className="status-message">Updating graph...</span>}
+          {budgetExceeded && (
+            <span className="status-message warning">
+              Budget exceeded ({stats.nodes} nodes, {stats.edges} edges). Partial view.
+            </span>
+          )}
         </div>
       )}
       <div ref={containerRef} className="viz-container" style={{ height: '600px', width: '100%' }} />

--- a/src/features/mindmap/MindMapView.tsx
+++ b/src/features/mindmap/MindMapView.tsx
@@ -1,39 +1,114 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import MindElixir, { type Options } from 'mind-elixir';
 import { Entity } from '../../lib/validation';
+import { jobCoordinator } from '../../lib/jobs';
 
 interface Props {
   rootEntity: Entity;
   relatedEntities: Entity[];
 }
 
+const MAX_MINDMAP_NODES = 50;
+
+interface MindMapData {
+  id: string;
+  topic: string;
+  children: { id: string; topic: string }[];
+}
+
 const MindMapView: React.FC<Props> = ({ rootEntity, relatedEntities }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [isActive, setIsActive] = useState(false);
+  const [isComputing, setIsComputing] = useState(false);
+  const [budgetExceeded, setBudgetExceeded] = useState(false);
+  const [nodeData, setNodeData] = useState<MindMapData | null>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!isActive) return;
+
+    setIsComputing(true);
+    jobCoordinator.enqueue< { nodeData: MindMapData, budgetExceeded: boolean } >({
+      id: `mindmap-prep-${Date.now()}`,
+      type: 'mindmap-data-prep',
+      payload: { rootEntity, relatedEntities },
+      coalesceKey: 'mindmap-prep',
+      execute: async (signal) => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        if (signal.aborted) throw new Error('AbortError');
+
+        const limitedEntities = relatedEntities.slice(0, MAX_MINDMAP_NODES);
+        return {
+          nodeData: {
+            id: rootEntity.id ?? 'root',
+            topic: rootEntity.name,
+            children: limitedEntities.map(e => ({
+              id: e.id ?? Math.random().toString(),
+              topic: e.name
+            }))
+          },
+          budgetExceeded: relatedEntities.length > MAX_MINDMAP_NODES
+        };
+      },
+      onComplete: (result) => {
+        setNodeData(result.nodeData);
+        setBudgetExceeded(result.budgetExceeded);
+        setIsComputing(false);
+      },
+      onError: () => setIsComputing(false)
+    });
+  }, [isActive, rootEntity, relatedEntities]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !isActive || !nodeData) return;
 
     const options: Options = {
-      el: containerRef.current,
+      el: container,
       direction: 2, // SIDE
     };
 
     const mind = new MindElixir(options);
-
     mind.init({
-      nodeData: {
-        id: rootEntity.id ?? 'root',
-        topic: rootEntity.name,
-        // root: true, // Type definition might not include this in some versions
-        children: relatedEntities.map(e => ({
-          id: e.id ?? Math.random().toString(),
-          topic: e.name
-        }))
-      }
+      nodeData: nodeData
     });
-  }, [rootEntity, relatedEntities]);
 
-  return <div ref={containerRef} className="viz-container" />;
+    return () => {
+        // MindElixir doesn't have a direct kill() in some versions,
+        // but we can clear the container.
+        if (container) {
+            container.innerHTML = '';
+        }
+    };
+  }, [isActive, nodeData]);
+
+  if (!isActive) {
+    return (
+      <div className="mindmap-container cold-state" style={{
+        height: '600px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        background: 'var(--bg-secondary)',
+        borderRadius: '8px'
+      }}>
+        <p>Mind Map View is currently inactive to save resources.</p>
+        <button className="btn-primary" onClick={() => setIsActive(true)}>
+          Activate Mind Map
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mindmap-container">
+        <div className="viz-toolbar">
+            {isComputing && <span className="status-message">Preparing mind map...</span>}
+            {budgetExceeded && <span className="status-message warning">Showing first {MAX_MINDMAP_NODES} related entities.</span>}
+        </div>
+        <div ref={containerRef} className="viz-container" style={{ height: '600px', width: '100%' }} />
+    </div>
+  );
 };
 
 export default MindMapView;

--- a/src/lib/jobs.ts
+++ b/src/lib/jobs.ts
@@ -1,0 +1,118 @@
+import { logger } from './logger';
+
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface JobMetrics {
+  queued: number;
+  running: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  coalesced: number;
+  totalExecutionTime: number;
+}
+
+export interface Job<T = unknown> {
+  id: string;
+  type: string;
+  payload: unknown;
+  execute: (signal: AbortSignal) => Promise<T>;
+  onComplete?: (result: T) => void;
+  onError?: (error: Error) => void;
+  coalesceKey?: string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+class JobCoordinator {
+  private queue: Job<any>[] = [];
+  private activeJobs = new Map<string, { job: Job<any>; controller: AbortController }>();
+  private metrics: JobMetrics = {
+    queued: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    cancelled: 0,
+    coalesced: 0,
+    totalExecutionTime: 0,
+  };
+  private listeners: ((metrics: JobMetrics) => void)[] = [];
+
+  enqueue<T>(job: Job<T>) {
+    if (job.coalesceKey) {
+      const existingIndex = this.queue.findIndex(j => j.coalesceKey === job.coalesceKey);
+      if (existingIndex !== -1) {
+        this.queue.splice(existingIndex, 1);
+        this.metrics.coalesced++;
+      }
+
+      const activeJob = this.activeJobs.get(job.coalesceKey);
+      if (activeJob) {
+        activeJob.controller.abort();
+        this.activeJobs.delete(job.coalesceKey);
+        this.metrics.cancelled++;
+        this.metrics.running--;
+      }
+    }
+
+    this.queue.push(job);
+    this.metrics.queued++;
+    this.notify();
+    this.processQueue();
+  }
+
+  private async processQueue() {
+    if (this.queue.length === 0 || this.activeJobs.size >= 4) return;
+
+    const job = this.queue.shift()!;
+    this.metrics.queued--;
+    this.metrics.running++;
+    this.notify();
+
+    const controller = new AbortController();
+    const key = job.coalesceKey || job.id;
+    this.activeJobs.set(key, { job, controller });
+
+    const startTime = performance.now();
+    try {
+      const result = await job.execute(controller.signal);
+      if (!controller.signal.aborted) {
+        this.metrics.completed++;
+        job.onComplete?.(result);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        // Handled as cancellation
+      } else {
+        logger.error(`Job ${job.id} (${job.type}) failed`, err);
+        this.metrics.failed++;
+        job.onError?.(err as Error);
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        this.activeJobs.delete(key);
+        this.metrics.running--;
+      }
+      this.metrics.totalExecutionTime += performance.now() - startTime;
+      this.notify();
+      this.processQueue();
+    }
+  }
+
+  subscribe(listener: (metrics: JobMetrics) => void) {
+    this.listeners.push(listener);
+    listener({ ...this.metrics });
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener);
+    };
+  }
+
+  private notify() {
+    this.listeners.forEach(l => l({ ...this.metrics }));
+  }
+
+  getMetrics() {
+    return { ...this.metrics };
+  }
+}
+
+export const jobCoordinator = new JobCoordinator();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
This PR makes the Knowledge Graph and Mind Map views secondary, opt-in components that do not consume resources until explicitly activated. It introduces a `JobCoordinator` architectural pattern to handle expensive data computations in the background, supporting task coalescing and cancellation.

Key changes:
- **Opt-in Activation**: Graph and Mind Map views start in a "cold" state.
- **Render Budgets**: Explicit node and edge limits are enforced to prevent browser performance degradation.
- **Job Coordinator**: A new subsystem for managing background tasks with performance metrics.
- **Performance Monitoring**: A `JobMetrics` panel (in DEV mode) tracks execution times and UI renders.
- **Lazy Loading Optimization**: Data refresh logic in `App.tsx` is now more selective.

Fixes #45

---
*PR created automatically by Jules for task [9609212587085841644](https://jules.google.com/task/9609212587085841644) started by @d-oit*