### PR TITLE
Fix XSS vulnerability in static site export

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,7 +3,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { initDb } from '../src/db/client.js';
 import { repository } from '../src/db/repository.js';
-import type { Claim, Note } from '../src/lib/validation';
+import type { Claim, Note } from '../src/lib/validation.js';
+import { escapeHtml } from '../src/lib/security.js';
+import { stripHtml } from '../src/lib/nlp.js';
 
 const program = new Command();
 
@@ -145,6 +147,7 @@ async function exportSite(outDir: string) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline';">
   <title>Knowledge Base</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; line-height: 1.6; }
@@ -168,17 +171,18 @@ async function exportSite(outDir: string) {
     const safeId = entity.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
     
     html += `\n  <div class="entity" id="${safeId}">\n`;
-    html += `    <h2><a href="#${safeId}">${entity.name}</a></h2>\n`;
-    html += `    <span class="type">${entity.type}</span>\n`;
+    html += `    <h2><a href="#${safeId}">${escapeHtml(entity.name)}</a></h2>\n`;
+    html += `    <span class="type">${escapeHtml(entity.type)}</span>\n`;
     
     if (entity.description) {
-      html += `\n    <p>${entity.description}</p>\n`;
+      const safeDesc = escapeHtml(stripHtml(entity.description));
+      html += `\n    <p>${safeDesc}</p>\n`;
     }
     
     if (claims.length > 0) {
       html += `\n    <h3>Claims</h3>\n`;
       for (const claim of claims) {
-        html += `    <div class="claim">${claim.statement}`;
+        html += `    <div class="claim">${escapeHtml(claim.statement)}`;
         if (claim.confidence !== 1) html += ` <em>(confidence: ${claim.confidence})</em>`;
         html += `</div>\n`;
       }

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1,0 +1,17 @@
+/**
+ * Security utilities for the Knowledge Studio.
+ */
+
+/**
+ * Escapes HTML special characters in a string to prevent XSS.
+ * Handles <, >, &, ", and '.
+ */
+export const escapeHtml = (unsafe: string): string => {
+  if (!unsafe) return '';
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};


### PR DESCRIPTION
Identified and fixed a Cross-Site Scripting (XSS) vulnerability in the static site export functionality. The CLI tool was previously concatenating unsanitized database content directly into HTML strings. 

The fix involves:
1. Introducing a robust `escapeHtml` utility in `src/lib/security.ts`.
2. Applying HTML escaping to all user-visible fields (`name`, `type`, `statement`) in the `exportSite` function.
3. Sanitizing entity descriptions by stripping HTML tags before escaping, providing a safe fallback for the static export.
4. Adding a restrictive Content Security Policy (CSP) via a `<meta>` tag to the exported HTML for defense-in-depth.
5. Correcting a missing `.js` extension in `cli/index.ts` to ensure ESM loader compatibility.

Verified the fix with reproduction scripts and ensured all existing tests and quality gates pass.

---
*PR created automatically by Jules for task [8963258749412759036](https://jules.google.com/task/8963258749412759036) started by @d-oit*