### PR TITLE
fix(ci): use JS comment in dependabot-auto-merge script

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const MAX_RETRIES = 60;  # Increased from 24 (now ~30 minutes)
+            const MAX_RETRIES = 60;  // Increased from 24 (now ~30 minutes)
             const POLL_INTERVAL_MS = 30000;
             for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
               const { data: status } = await github.rest.repos.getCombinedStatusForRef({


### PR DESCRIPTION
The script block in the dependabot-auto-merge workflow was using a YAML comment '#' instead of a JavaScript comment '//'. This caused a SyntaxError during execution. Replacing '#' with '//' resolves the issue.

---
*PR created automatically by Jules for task [14409151868462808992](https://jules.google.com/task/14409151868462808992) started by @d-oit*