### PR TITLE
feat(ui): Phase 2 - Responsive App Shell Cleanup

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,8 @@ import MobileDrawer from '../components/MobileDrawer';
 import SearchPanel from '../features/search/SearchPanel';
 import ErrorBoundary from '../components/ErrorBoundary';
 import Editor from '../features/editor/Editor';
+import { useMediaQuery } from '../hooks/useMediaQuery';
+import { MEDIA_QUERIES } from '../lib/constants';
 
 const GraphControls = lazy(() => import('../features/graph/GraphControls'));
 const GraphView = lazy(() => import('../features/graph/GraphView'));
@@ -70,21 +72,26 @@ const AppContent: React.FC = () => {
     }
   }, [currentView, dbReady, refreshData]);
 
+  const isMobile = useMediaQuery(MEDIA_QUERIES.MOBILE);
+
   if (error) return <div className="error-screen">{error}</div>;
 
   return (
     <div className="layout-container">
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
       <Header
         onMenuClick={() => setIsMenuOpen(true)}
         onSearchClick={() => setIsSearchOpen(true)}
       />
 
       <div className="layout-body">
-        <aside className="desktop-sidebar">
+        <aside className="desktop-sidebar" aria-label="Primary Navigation">
           <SidebarNav currentView={currentView} setCurrentView={setCurrentView} />
         </aside>
 
-        <main className="main-content">
+        <main id="main-content" className="main-content" aria-label="Main Workspace">
           {!dbReady && <div className="loading-screen">Booting Knowledge Studio...</div>}
           <ErrorBoundary fallback={<div className="error-state">Failed to load component. Please refresh.</div>}>
             <Suspense fallback={<LoadingSpinner />}>
@@ -97,7 +104,7 @@ const AppContent: React.FC = () => {
                   onFocusModeChange={setGraphFocusMode}
                   selectedNode={graphSelectedNode}
                   onSelectedNodeChange={setGraphSelectedNode}
-                  hideToolbar={window.innerWidth < 768}
+                  hideToolbar={isMobile}
                 />
               )}
               {dbReady && currentView === 'mindmap' && entities.length > 0 && (
@@ -116,7 +123,7 @@ const AppContent: React.FC = () => {
           </ErrorBoundary>
         </main>
 
-        <aside className="search-sidebar">
+        <aside className="search-sidebar" aria-label="Search and Discovery">
           <SearchPanel onResultClick={handleSearchResultClick} />
         </aside>
       </div>

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -23,7 +23,7 @@ const SidebarNav: React.FC<SidebarNavProps> = ({ currentView, setCurrentView, on
   };
 
   return (
-    <nav className="sidebar-nav">
+    <nav className="sidebar-nav" aria-label="Main Menu">
       <div className="brand">Knowledge Studio</div>
       <ul className="nav-links">
         {(['editor', 'graph', 'mindmap', 'chat', 'export', 'ai'] as View[]).map((view) => (

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook to listen for media query changes.
+ * @param query Media query string (e.g., '(max-width: 768px)')
+ * @returns boolean indicating if the query matches
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const listener = () => setMatches(media.matches);
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }, [query, matches]);
+
+  return matches;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Responsive Breakpoints
+ */
+export const BREAKPOINTS = {
+  MOBILE: 768,
+  TABLET: 1024,
+  DESKTOP: 1200,
+} as const;
+
+/**
+ * Media Queries
+ */
+export const MEDIA_QUERIES = {
+  MOBILE: `(max-width: ${BREAKPOINTS.MOBILE}px)`,
+  TABLET: `(max-width: ${BREAKPOINTS.TABLET}px)`,
+  DESKTOP: `(max-width: ${BREAKPOINTS.DESKTOP}px)`,
+} as const;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -3,12 +3,26 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
+  min-width: 0;
+  min-height: 0;
 }
 
 .layout-body {
   display: flex;
   flex: 1;
   overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
 }
 
 .mobile-header {
@@ -43,6 +57,7 @@
   overflow-y: auto;
 }
 
+/* Breakpoints consistent with src/lib/constants.ts */
 @media (max-width: 1200px) {
   .search-sidebar {
     display: none;
@@ -51,7 +66,7 @@
     display: flex;
   }
   .mobile-header .icon-button:last-child {
-    display: flex; /* Ensure search button is visible when sidebar is hidden */
+    display: flex;
   }
 }
 
@@ -66,7 +81,7 @@
 
 @media (min-width: 769px) and (max-width: 1200px) {
   .mobile-header .icon-button:first-child {
-    display: none; /* Hide menu button on desktop/tablet if sidebar is visible */
+    display: none;
   }
   .mobile-header .mobile-brand {
     margin-left: var(--space-4);
@@ -77,4 +92,20 @@
   .mobile-header {
     display: none;
   }
+}
+
+/* Accessibility: Skip link */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: var(--interactive-primary);
+  color: white;
+  padding: var(--space-2) var(--space-4);
+  z-index: 9999;
+  transition: top 0.2s;
+}
+
+.skip-link:focus {
+  top: 0;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -63,6 +63,11 @@
   --sidebar-width: 260px;
   --search-sidebar-width: 300px;
   --header-height: 60px;
+
+  /* Breakpoints */
+  --breakpoint-mobile: 768px;
+  --breakpoint-tablet: 1024px;
+  --breakpoint-desktop: 1200px;
 }
 
 /* Base Styles */


### PR DESCRIPTION
Modernize the responsive app shell with proper breakpoints, semantic landmarks, and mobile-first behavior.
- Replace direct window.innerWidth viewport reads in App.tsx render with useMediaQuery hook
- Normalize breakpoints across TypeScript and CSS
- Add 100dvh fallback pattern to shell containers
- Add min-width: 0 / min-height: 0 to flex/grid containers to prevent overflow
- Add labelled landmarks (aria-label) to <nav>, <main>, <aside>
- Add skip link before repeated navigation

Fixes #76

---
*PR created automatically by Jules for task [10043113980611103815](https://jules.google.com/task/10043113980611103815) started by @d-oit*