### PR TITLE
fix(security): sanitize exported site and add CSP

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,7 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { initDb } from '../src/db/client.js';
 import { repository } from '../src/db/repository.js';
-import type { Claim, Note } from '../src/lib/validation';
+import type { Claim, Note } from '../src/lib/validation.js';
+import { escapeHtml } from '../src/lib/security.js';
 
 const program = new Command();
 
@@ -145,6 +146,7 @@ async function exportSite(outDir: string) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
   <title>Knowledge Base</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; line-height: 1.6; }
@@ -168,17 +170,17 @@ async function exportSite(outDir: string) {
     const safeId = entity.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
     
     html += `\n  <div class="entity" id="${safeId}">\n`;
-    html += `    <h2><a href="#${safeId}">${entity.name}</a></h2>\n`;
-    html += `    <span class="type">${entity.type}</span>\n`;
+    html += `    <h2><a href="#${safeId}">${escapeHtml(entity.name)}</a></h2>\n`;
+    html += `    <span class="type">${escapeHtml(entity.type)}</span>\n`;
     
     if (entity.description) {
-      html += `\n    <p>${entity.description}</p>\n`;
+      html += `\n    <p>${escapeHtml(entity.description)}</p>\n`;
     }
     
     if (claims.length > 0) {
       html += `\n    <h3>Claims</h3>\n`;
       for (const claim of claims) {
-        html += `    <div class="claim">${claim.statement}`;
+        html += `    <div class="claim">${escapeHtml(claim.statement)}`;
         if (claim.confidence !== 1) html += ` <em>(confidence: ${claim.confidence})</em>`;
         html += `</div>\n`;
       }

--- a/src/db/connection-pool.ts
+++ b/src/db/connection-pool.ts
@@ -1,4 +1,4 @@
-import { logger } from '../lib/logger';
+import { logger } from '../lib/logger.js';
 
 export const DEFAULT_POOL_SIZE = 4;
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds default timeout

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -1,7 +1,7 @@
-import { getDb, SQLiteDB } from './client';
-import { Entity, Claim, Note, Link, GraphSnapshot } from '../lib/validation';
-import { AppError } from '../lib/errors';
-import { logger } from '../lib/logger';
+import { getDb, SQLiteDB } from './client.js';
+import { Entity, Claim, Note, Link, GraphSnapshot } from '../lib/validation.js';
+import { AppError } from '../lib/errors.js';
+import { logger } from '../lib/logger.js';
 
 export interface GraphSnapshotDiff {
   added_nodes: string[];

--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml } from '../security';
+
+describe('security utilities', () => {
+  describe('escapeHtml', () => {
+    it('should escape HTML special characters', () => {
+      const input = '<script>alert("XSS & attack")</script>\'';
+      const expected = '&lt;script&gt;alert(&quot;XSS &amp; attack&quot;)&lt;/script&gt;&#039;';
+      expect(escapeHtml(input)).toBe(expected);
+    });
+
+    it('should handle strings without special characters', () => {
+      const input = 'Hello World 123';
+      expect(escapeHtml(input)).toBe(input);
+    });
+
+    it('should escape repeated characters', () => {
+      const input = '<<<<';
+      const expected = '&lt;&lt;&lt;&lt;';
+      expect(escapeHtml(input)).toBe(expected);
+    });
+  });
+});

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1,0 +1,15 @@
+/**
+ * Security utilities for the Knowledge Studio.
+ */
+
+/**
+ * Escapes HTML special characters to prevent XSS.
+ */
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}


### PR DESCRIPTION
Identified and fixed a potential XSS vulnerability in the CLI's site export functionality. User-controlled data was being injected directly into the exported HTML without sanitization.

Changes:
1. Created `src/lib/security.ts` with a robust `escapeHtml` function.
2. Updated `cli/index.ts` to sanitize all dynamic content (entity names, descriptions, claims) in the `exportSite` function.
3. Added a restrictive CSP meta tag (`default-src 'none'; style-src 'unsafe-inline';`) to the exported HTML template as a defense-in-depth measure.
4. Corrected ESM import paths (adding `.js` extensions) in several files to ensure the CLI tool works with the Node.js ESM loader.
5. Added unit tests for the new security utility in `src/lib/__tests__/security.test.ts`.

All tests passed, and the changes were reviewed for correctness and security best practices.

---
*PR created automatically by Jules for task [16334729237238505286](https://jules.google.com/task/16334729237238505286) started by @d-oit*