### PR TITLE
Split TypeScript configs for app, tests, and Node-side tooling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,9 +13,6 @@ export default tseslint.config(
       'playwright-report',
       'test-results',
       '.agents',
-      'cli',
-      '*.cjs',
-      '*.config.*',
     ],
   },
   js.configs.recommended,
@@ -24,10 +21,34 @@ export default tseslint.config(
   react.configs.flat['jsx-runtime'],
   jsxA11y.flatConfigs.recommended,
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.json'],
+        project: ['./tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ['tests/**/*.{ts,tsx}', 'src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}', 'src/test/setup.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.test.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ['cli/**/*.ts', 'scripts/**/*.ts', '*.config.{ts,js,cjs}', '*.config.*.{ts,js,cjs}', 'eslint.config.js'],
+    languageOptions: {
+      globals: {
+        module: 'readonly',
+        process: 'readonly',
+        require: 'readonly',
+        __dirname: 'readonly',
+      },
+      parserOptions: {
+        project: ['./tsconfig.node.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -p tsconfig.app.json && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:strict": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
@@ -31,7 +31,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ci": "npm run build && PLAYWRIGHT_MODE=production playwright test",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "cli": "node --loader ts-node/esm cli/index.ts"
   },
   "dependencies": {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types/app",
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**", "src/test/setup.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,8 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
-     "types": ["vite/client", "node", "vitest/globals"]
-  },
-  "include": ["src", "cli", "tests"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,27 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "allowJs": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types/node",
+    "types": ["node", "vite/client"]
+  },
+  "include": [
+    "cli",
+    "scripts",
+    "src/db/client.ts",
+    "src/db/repository.ts",
+    "src/db/connection-pool.ts",
+    "src/lib/logger.ts",
+    "src/lib/errors.ts",
+    "src/lib/validation.ts",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "eslint.config.js",
+    "commitlint.config.cjs",
+    "src/test/setup.ts"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types/test",
+    "types": ["node", "vitest/globals", "vite/client"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/__tests__/**/*",
+    "src/test/setup.ts",
+    "tests"
+  ],
+  "references": [
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,10 +25,12 @@ export default defineConfig({
       ],
       // Thresholds are set to reflect the broad inclusion of UI/feature modules
       // while maintaining a baseline for future growth.
-      branches: 14,
-      functions: 16,
-      lines: 25,
-      statements: 24,
+      thresholds: {
+        branches: 14,
+        functions: 16,
+        lines: 25,
+        statements: 24,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
Split the monolithic `tsconfig.json` into specialized configurations for the browser application, testing code, and Node-side tooling (CLI, scripts, and configs). This separation ensures that each execution context uses appropriate compiler settings and types, reducing incidental coupling and making type errors more meaningful. 

The root `tsconfig.json` now serves as a project orchestrator using Project References. ESLint has been updated to support these multiple projects, enabling type-aware linting for previously ignored areas like the `cli/` directory. 

Build and typecheck scripts were updated to align with the new structure. All verification steps (build, lint, tests) were successfully executed to ensure no regressions were introduced.

Fixes #98

---
*PR created automatically by Jules for task [1520440758500423346](https://jules.google.com/task/1520440758500423346) started by @d-oit*