### PR TITLE
Optimize incremental search index updates

### DIFF
--- a/src/lib/__tests__/search_perf.test.ts
+++ b/src/lib/__tests__/search_perf.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { repository } from '../../db/repository.js';
+import { upsertToSearchIndex, initSearch } from '../search.js';
+
+vi.mock('../../db/repository.js', () => ({
+  repository: {
+    getAllEntities: vi.fn(),
+    getClaimsByEntityId: vi.fn(),
+    getAllClaims: vi.fn(),
+    getEntityById: vi.fn(),
+    exec: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe('Search Incremental Update Benchmark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it('measures upsertToSearchIndex performance with 100 claims', async () => {
+    const entityId = 'entity-1';
+    const entity = {
+      id: entityId,
+      rowid: 1,
+      name: 'Test Entity',
+      type: 'person',
+      description: 'A test entity description',
+    };
+
+    const claims = Array.from({ length: 100 }, (_, i) => ({
+      id: `claim-${i}`,
+      rowid: i + 100,
+      entity_id: entityId,
+      statement: `Claim statement number ${i}`,
+      confidence: 1,
+      verification_status: 'unverified',
+    }));
+
+    (repository.getAllEntities as Mock).mockResolvedValue([entity]);
+    (repository.getAllClaims as Mock).mockResolvedValue(claims);
+    (repository.getEntityById as Mock).mockResolvedValue(entity);
+    (repository.getClaimsByEntityId as Mock).mockResolvedValue(claims);
+
+    // Initialize search first
+    await initSearch();
+
+    const upsertPromise = upsertToSearchIndex(entityId);
+
+    // Fast-forward debounce timer
+    vi.runAllTimers();
+    await upsertPromise;
+
+    // Optimized, it calls getClaimsByEntityId 1 time:
+    // 1. upsertToSearchIndex (passed to other functions)
+    expect(repository.getClaimsByEntityId).toHaveBeenCalledTimes(1);
+
+    // initSearch calls exec 2 times (rebuild entity and claim index)
+    // removeFromSearchIndex calls exec 1 (entity delete) and 1 (claims delete set-based)
+    // upsertToSearchIndex calls exec 1 (entity insert) and 1 (claims insert set-based)
+    // Total exec calls expected: 2 + 2 + 2 = 6.
+    expect(repository.exec).toHaveBeenCalledTimes(6);
+  });
+});

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -59,7 +59,9 @@ export const initSearch = async () => {
   if (oramaDb) return oramaDb;
 
   try {
-    oramaDb = create({
+    oramaDb = (await create({
+      schema: searchSchema,
+    })) as Orama<OramaSchema>;
       schema: searchSchema,
     }) as Orama<OramaSchema>;
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -59,9 +59,7 @@ export const initSearch = async () => {
   if (oramaDb) return oramaDb;
 
   try {
-    oramaDb = (await create({
-      schema: searchSchema,
-    })) as Orama<OramaSchema>;
+    oramaDb = create({
       schema: searchSchema,
     }) as Orama<OramaSchema>;
 
@@ -157,12 +155,7 @@ export const upsertToSearchIndex = async (entityId: string) => {
       try {
         // Fetch everything once
         const entity = await repository.getEntityById(entityId);
-        const entity = await repository.getEntityById(entityId);
-        if (!entity) {
-          await removeFromSearchIndex(entityId);
-          resolve();
-          return;
-        }
+        if (!entity) return;
 
         const claims = await repository.getClaimsByEntityId(entityId);
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -39,27 +39,19 @@ const addEntityToIndex = async (entity: Entity, claims: Claim[]): Promise<void> 
   const entityResult = await insert(oramaDb, entityDoc);
   oramaIdMap.set(entity.id!, entityResult);
 
-  for (const claim of claims) {
-    const claimDoc: SearchDocument = {
+  if (claims.length > 0) {
+    const claimDocs: SearchDocument[] = claims.map(claim => ({
       id: claim.id!,
       type: 'claim',
       title: entity.name,
       content: compressText(claim.statement),
       keywords: [entity.id!, claim.source || 'unknown'].join(','),
-    };
-    const claimResult = await insert(oramaDb, claimDoc);
-    oramaIdMap.set(claim.id!, claimResult);
-  }
-};
+    }));
 
-/**
- * Helper to index an entity and its claims.
- */
-const indexEntityById = async (entityId: string): Promise<void> => {
-  const entity = await repository.getEntityById(entityId);
-  if (entity) {
-    const claims = await repository.getClaimsByEntityId(entity.id!);
-    await addEntityToIndex(entity, claims);
+    const claimOramaIds = await insertMultiple(oramaDb, claimDocs);
+    for (let i = 0; i < claims.length; i++) {
+      oramaIdMap.set(claims[i].id!, claimOramaIds[i]);
+    }
   }
 };
 
@@ -67,9 +59,9 @@ export const initSearch = async () => {
   if (oramaDb) return oramaDb;
 
   try {
-    oramaDb = await create({
+    oramaDb = create({
       schema: searchSchema,
-    });
+    }) as Orama<OramaSchema>;
 
     const [entities, allClaims] = await Promise.all([
       repository.getAllEntities(),
@@ -154,35 +146,43 @@ export const upsertToSearchIndex = async (entityId: string) => {
   }
 
   return new Promise<void>((resolve) => {
-    const timer = setTimeout(async () => {
-      debounceTimers.delete(entityId);
+    const timer = setTimeout(() => {
+      void (async () => {
+        debounceTimers.delete(entityId);
 
       if (!oramaDb) await initSearch();
 
       try {
-        await removeFromSearchIndex(entityId);
-        await indexEntityById(entityId);
-
-        // Incrementally update SQLite FTS5 index
+        // Fetch everything once
         const entity = await repository.getEntityById(entityId);
-        if (entity) {
-          await repository.exec({
-            sql: `INSERT INTO entity_search_idx(rowid, name, description) VALUES (?, ?, ?)`,
-            bind: [entity.rowid, entity.name, entity.description || '']
-          });
+        if (!entity) return;
 
-          const claims = await repository.getClaimsByEntityId(entityId);
-          for (const claim of claims) {
-            await repository.exec({
-              sql: `INSERT INTO claim_search_idx(rowid, statement) VALUES (?, ?)`,
-              bind: [claim.rowid, claim.statement]
-            });
-          }
+        const claims = await repository.getClaimsByEntityId(entityId);
+
+        // Optimized removal using pre-fetched data
+        await removeFromSearchIndex(entityId, entity, claims);
+
+        // Optimized Orama insertion using insertMultiple
+        await addEntityToIndex(entity, claims);
+
+        // Incrementally update SQLite FTS5 index using set-based INSERT
+        await repository.exec({
+          sql: `INSERT INTO entity_search_idx(rowid, name, description) VALUES (?, ?, ?)`,
+          bind: [entity.rowid, entity.name, entity.description || '']
+        });
+
+        if (claims.length > 0) {
+          await repository.exec({
+            sql: `INSERT INTO claim_search_idx(rowid, statement)
+                  SELECT rowid, statement FROM claims WHERE entity_id = ?`,
+            bind: [entityId]
+          });
         }
       } catch (err) {
         logger.error(`Failed to upsert entity ${entityId} to search index`, err);
       }
       resolve();
+      })();
     }, 500);
     debounceTimers.set(entityId, timer);
   });
@@ -191,18 +191,24 @@ export const upsertToSearchIndex = async (entityId: string) => {
 /**
  * Removes an entity and its claims from the search index.
  */
-export const removeFromSearchIndex = async (entityId: string) => {
+export const removeFromSearchIndex = async (
+  entityId: string,
+  providedEntity?: Entity & { rowid: number },
+  providedClaims?: (Claim & { rowid: number })[]
+) => {
   if (!oramaDb) return;
 
   try {
     const oramaInternalId = oramaIdMap.get(entityId);
+    const oramaRemovals: Promise<unknown>[] = [];
+
     if (oramaInternalId) {
-      await remove(oramaDb, oramaInternalId);
+      oramaRemovals.push(remove(oramaDb, oramaInternalId));
       oramaIdMap.delete(entityId);
     }
 
-    // SQLite FTS5 removal
-    const entity = await repository.getEntityById(entityId);
+    // SQLite FTS5 removal for entity
+    const entity = providedEntity ?? await repository.getEntityById(entityId);
     if (entity) {
       await repository.exec({
         sql: `DELETE FROM entity_search_idx WHERE rowid = ?`,
@@ -210,19 +216,23 @@ export const removeFromSearchIndex = async (entityId: string) => {
       });
     }
 
-    const claims = await repository.getClaimsByEntityId(entityId);
+    const claims = providedClaims ?? await repository.getClaimsByEntityId(entityId);
     for (const claim of claims) {
       const claimOramaId = oramaIdMap.get(claim.id!);
       if (claimOramaId) {
-        await remove(oramaDb, claimOramaId);
+        oramaRemovals.push(remove(oramaDb, claimOramaId));
         oramaIdMap.delete(claim.id!);
       }
+    }
 
-      // SQLite FTS5 removal
-      await repository.exec({
-        sql: `DELETE FROM claim_search_idx WHERE rowid = ?`,
-        bind: [claim.rowid]
-      });
+    // Single set-based SQLite FTS5 removal for all claims of this entity
+    await repository.exec({
+      sql: `DELETE FROM claim_search_idx WHERE rowid IN (SELECT rowid FROM claims WHERE entity_id = ?)`,
+      bind: [entityId]
+    });
+
+    if (oramaRemovals.length > 0) {
+      await Promise.all(oramaRemovals);
     }
   } catch (err) {
     logger.error(`Failed to remove entity ${entityId} from search index`, err);

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -155,7 +155,12 @@ export const upsertToSearchIndex = async (entityId: string) => {
       try {
         // Fetch everything once
         const entity = await repository.getEntityById(entityId);
-        if (!entity) return;
+        const entity = await repository.getEntityById(entityId);
+        if (!entity) {
+          await removeFromSearchIndex(entityId);
+          resolve();
+          return;
+        }
 
         const claims = await repository.getClaimsByEntityId(entityId);
 


### PR DESCRIPTION
Optimized the incremental search index update process by reducing database round-trips and batching search engine operations. Specifically, for an entity with N claims, the number of SQLite `exec` calls was reduced from approximately 2N to a constant number, and Orama insertions were batched using `insertMultiple`. A benchmark test was added to verify these improvements.

---
*PR created automatically by Jules for task [5013845050625037638](https://jules.google.com/task/5013845050625037638) started by @d-oit*