### PR TITLE
ci(#194): add Playwright cache, pip cache, concurrency group

### DIFF
--- a/.github/workflows/ci-and-labels.yml
+++ b/.github/workflows/ci-and-labels.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -100,6 +104,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      # quality-gate runs tests on changed files only (via quality_gate.sh --changed);
+      # this job runs the full test suite to catch regressions outside the change set.
       - name: Run Vitest
         run: pnpm test
 
@@ -122,7 +128,17 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Cache Playwright Browsers
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+      - name: Install Playwright Dependencies (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
       - name: Run E2E Tests
         run: pnpm run test:e2e:ci

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -105,6 +105,15 @@ jobs:
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Run quality gate
         id: quality
         run: |

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.x'
+          cache: 'pip'
 
       - name: Install yamllint
         run: pip install yamllint


### PR DESCRIPTION
## Summary

Adds CI optimizations for faster builds:

- **Playwright browser cache**: Caches `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml` hash. On cache hit, only runs `install-deps` (~50MB vs ~500MB full download).
- **pip cache**: Adds `cache: 'pip'` to `yaml-lint.yml` Python setup to cache yamllint between runs.
- **Concurrency group**: Adds `concurrency: ci-${{ github.ref }}` with `cancel-in-progress: true` to cancel superseded CI runs.
- **Fix cleanup workflow**: Adds missing Node.js/pnpm setup steps to `cleanup.yml` which was previously running quality gate without dependencies installed.

Closes #194