### PR TITLE
security(#170): document local-first security model and add VITE_ audit script

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,33 @@ Example:
 - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 ```
 
+## Local-First Security Model
+
+This application is a **local-first** knowledge studio. All data, including API
+keys, stays on the user's device.
+
+### API Key Handling
+
+- **User-provided keys**: API keys for LLM providers (OpenRouter, OpenAI, etc.)
+  are entered by the user in the application settings UI and stored in the
+  browser's `localStorage`.
+- **No backend storage**: Keys are never sent to, stored on, or transmitted
+  through any server. All LLM API calls are made directly from the browser.
+- **VITE_ environment variables**: Variables prefixed with `VITE_` are compiled
+  into the JavaScript bundle at build time and are **visible to anyone who
+  inspects the client-side source**. These should only be used for user-provided
+  API keys, never for developer secrets or infrastructure credentials.
+- **No secrets in source code**: API keys must never be hardcoded in source files,
+  committed to version control, or included in build artifacts.
+
+### Recommended Practices
+
+- Enter API keys through the application settings UI, not via `.env` files.
+- Treat any `VITE_` prefixed variable as public — only use it for values the
+  user is willing to expose in the browser.
+- Use the audit script (`scripts/audit-vite-env.sh`) to verify no secret
+  references leak into the client bundle.
+
 ## Scope
 
 This policy covers the source code, workflows, scripts, and configuration files

--- a/plans/ADRs/003-vite-env-security.md
+++ b/plans/ADRs/003-vite-env-security.md
@@ -1,7 +1,7 @@
 # ADR 003: API Key Isolation from VITE_ Environment Variables
 
 ## Status
-PROPOSED
+ACCEPTED (VITE_ env var references removed from LLM providers; audit script created; security model documented)
 
 ## Context
 API keys for LLM providers (OpenRouter, Kilo Gateway) are currently read from `import.meta.env.VITE_OPENROUTER_API_KEY` and `import.meta.env.VITE_KILO_API_KEY`. Vite environment variables prefixed with `VITE_` are exposed to the client-side bundle at build time. If the application is deployed (even as a static site), these keys would be visible in the JavaScript bundle.

--- a/scripts/audit-vite-env.sh
+++ b/scripts/audit-vite-env.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Audit script to detect VITE_ environment variable references that could expose secrets.
+# Run as part of CI or pre-commit checks to ensure no API keys leak into the client bundle.
+set -euo pipefail
+
+echo "=== VITE_ Environment Variable Audit ==="
+echo ""
+
+EXIT_CODE=0
+
+# Check for VITE_ references in source code (excluding node_modules, dist, tests, and .env files)
+echo "Scanning source code for import.meta.env.VITE_ references..."
+VITE_REFS=$(grep -r "import\.meta\.env\.VITE_" src/ \
+  --include="*.ts" --include="*.tsx" \
+  --exclude-dir="__tests__" \
+  --exclude-dir="node_modules" \
+  2>/dev/null || true)
+
+if [ -n "$VITE_REFS" ]; then
+  echo "WARNING: Found VITE_ environment variable references in source code:"
+  echo "$VITE_REFS"
+  echo ""
+  echo "VITE_ prefixed variables are exposed to the client bundle."
+  echo "Ensure these are user-provided keys, not developer secrets."
+  EXIT_CODE=1
+else
+  echo "OK: No import.meta.env.VITE_ references found in source code."
+fi
+
+echo ""
+
+# Check for hardcoded API key patterns
+echo "Scanning for hardcoded API key patterns..."
+HARDCODED_KEYS=$(grep -rE "(sk-[a-zA-Z0-9]{20,}|api[_-]?key\s*[:=]\s*['\"][a-zA-Z0-9]{20,})" src/ \
+  --include="*.ts" --include="*.tsx" \
+  --exclude-dir="__tests__" \
+  --exclude-dir="node_modules" \
+  2>/dev/null || true)
+
+if [ -n "$HARDCODED_KEYS" ]; then
+  echo "WARNING: Found potential hardcoded API keys:"
+  echo "$HARDCODED_KEYS"
+  echo ""
+  echo "API keys must never be hardcoded in source files."
+  EXIT_CODE=1
+else
+  echo "OK: No hardcoded API key patterns found."
+fi
+
+echo ""
+
+# Check .env.example documentation
+if [ -f .env.example ]; then
+  VITE_EXAMPLE=$(grep "^VITE_" .env.example 2>/dev/null || true)
+  if [ -n "$VITE_EXAMPLE" ]; then
+    echo "INFO: VITE_ variables found in .env.example:"
+    echo "$VITE_EXAMPLE"
+    echo ""
+    echo "Ensure .env.example documents that these are client-visible."
+  fi
+
+  # Check for warning comments
+  VITE_WARNING=$(grep -c "exposed to the client" .env.example 2>/dev/null || true)
+  if [ "$VITE_WARNING" -eq 0 ] && [ -n "$VITE_EXAMPLE" ]; then
+    echo "WARNING: .env.example has VITE_ variables but no exposure warning."
+    EXIT_CODE=1
+  fi
+fi
+
+echo ""
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "=== Audit Passed ==="
+else
+  echo "=== Audit Failed ==="
+  echo "Review the warnings above and ensure VITE_ variables are not leaking secrets."
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

Completes the security documentation for issue #170:

- **SECURITY.md**: Added `Local-First Security Model` section documenting API key handling, VITE_ exposure risks, and recommended practices
- **scripts/audit-vite-env.sh**: New audit script that scans for `import.meta.env.VITE_` references, hardcoded API key patterns, and verifies `.env.example` has exposure warnings
- **plans/ADRs/003-vite-env-security.md**: Updated status from PROPOSED to ACCEPTED

The core security fix (removing VITE_ env var references from LLM providers) was already implemented in a prior PR. This completes the documentation and adds automated auditing.

Closes #170