### PR TITLE
refactor(#191): extract shared fetchAllExportData and fix CLI N+1 query

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5,7 +5,7 @@ import { readFileSync } from 'fs';
 import { setDb } from '../src/db/client.js';
 import { initDb } from './db.js';
 import { repository } from '../src/db/repository.js';
-import { generateSiteHtml, generateJsonExport, generateEntityMarkdown } from '../src/lib/export-core.js';
+import { generateSiteHtml, generateJsonExport, generateEntityMarkdown, fetchAllExportData } from '../src/lib/export-core.js';
 import { runMigrations, rollbackLastMigration, getMigrationStatus } from '../src/db/migrate.js';
 
 const program = new Command();
@@ -127,13 +127,13 @@ program
   });
 
 async function exportMarkdown(outDir: string) {
-  const entities = await repository.getAllEntities();
-  
-  for (const entity of entities) {
+  const data = await fetchAllExportData(repository);
+
+  for (const entity of data.entities) {
     if (!entity.id) continue;
-    const claims = await repository.getClaimsByEntityId(entity.id);
-    const notes = await repository.getNotesByEntityId(entity.id);
-    
+    const claims = data.claims[entity.id] ?? [];
+    const notes = data.notes[entity.id] ?? [];
+
     const md = generateEntityMarkdown(entity, claims, notes);
 
     const safeName = entity.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
@@ -142,32 +142,13 @@ async function exportMarkdown(outDir: string) {
 }
 
 async function exportJson(outDir: string) {
-  const [entities, links, claims, notes] = await Promise.all([
-    repository.getAllEntities(),
-    repository.getAllLinks(),
-    repository.getAllClaimsGroupedByEntity(),
-    repository.getAllNotesGroupedByEntity(),
-  ]);
-  
-  const data = {
-    exported_at: new Date().toISOString(),
-    entities,
-    claims,
-    notes,
-    links,
-  };
-  
+  const data = await fetchAllExportData(repository);
   fs.writeFileSync(path.join(outDir, 'knowledge.json'), generateJsonExport(data));
 }
 
 async function exportSite(outDir: string) {
-  const [entities, claims, notes] = await Promise.all([
-    repository.getAllEntities(),
-    repository.getAllClaimsGroupedByEntity(),
-    repository.getAllNotesGroupedByEntity(),
-  ]);
-  
-  const html = generateSiteHtml({ entities, claims, notes });
+  const data = await fetchAllExportData(repository);
+  const html = generateSiteHtml(data);
   fs.writeFileSync(path.join(outDir, 'index.html'), html);
 }
 

--- a/src/features/export/ExportPanel.tsx
+++ b/src/features/export/ExportPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { logger } from '../../lib/logger';
 import { repository } from '../../db/repository';
-import { generateSiteHtml, generateMarkdownExport, generateJsonExport, generatePrintHtml } from '../../lib/export-core';
+import { generateSiteHtml, generateMarkdownExport, generateJsonExport, generatePrintHtml, fetchAllExportData } from '../../lib/export-core';
 import { stripHtmlTags } from '../../lib/security';
 import type { ExportData } from '../../lib/export-core';
 import { Download, File, FileJson, FileText, FileSpreadsheet, Globe, Loader2 } from 'lucide-react';
@@ -98,15 +98,12 @@ const ExportPanel: React.FC = () => {
     setIsExporting(true);
     setError(null);
     try {
-      const [entities, claims] = await Promise.all([
-        repository.getAllEntities(),
-        repository.getAllClaimsGroupedByEntity(),
-      ]);
+      const data = await fetchAllExportData(repository);
       const printWindow = window.open('', '_blank');
       if (!printWindow) throw new Error('Popup blocked');
       const printDoc = printWindow.document;
       printDoc.open();
-      printDoc.write(generatePrintHtml(entities, claims));
+      printDoc.write(generatePrintHtml(data.entities, data.claims));
       printDoc.close();
       printWindow.focus();
       setTimeout(() => printWindow.print(), 500);
@@ -124,10 +121,7 @@ const ExportPanel: React.FC = () => {
     setIsExporting(true);
     setError(null);
     try {
-      const [entities, claims] = await Promise.all([
-        repository.getAllEntities(),
-        repository.getAllClaimsGroupedByEntity(),
-      ]);
+      const data = await fetchAllExportData(repository);
       const { Document, Packer, Paragraph, HeadingLevel } = await import('docx');
 
       const doc = new Document({
@@ -136,18 +130,21 @@ const ExportPanel: React.FC = () => {
           children: [
             new Paragraph({ text: 'Knowledge Base Export', heading: HeadingLevel.TITLE }),
             new Paragraph({ text: `Exported on ${new Date().toLocaleString()}`, spacing: { after: 400 } }),
-            ...entities.flatMap(entity => [
-              new Paragraph({ text: stripHtmlTags(entity.name), heading: HeadingLevel.HEADING_1 }),
-              new Paragraph({ text: `Type: ${stripHtmlTags(entity.type)}`, spacing: { after: 200 } }),
-              ...(entity.description ? [new Paragraph({ text: stripHtmlTags(entity.description), spacing: { after: 200 } })] : []),
-              ...(claims[entity.id!]?.length ? [
-                new Paragraph({ text: 'Claims', heading: HeadingLevel.HEADING_2 }),
-                ...claims[entity.id!].map(claim => new Paragraph({
-                  text: `• ${stripHtmlTags(claim.statement)}${claim.confidence !== 1 ? ` (confidence: ${Math.round(claim.confidence * 100)}%)` : ''}`,
-                  spacing: { after: 100 },
-                })),
-              ] : []),
-            ]),
+            ...data.entities.filter((e): e is Entity & { id: string } => !!e.id).flatMap(entity => {
+              const entityClaims = data.claims[entity.id] ?? [];
+              return [
+                new Paragraph({ text: stripHtmlTags(entity.name), heading: HeadingLevel.HEADING_1 }),
+                new Paragraph({ text: `Type: ${stripHtmlTags(entity.type)}`, spacing: { after: 200 } }),
+                ...(entity.description ? [new Paragraph({ text: stripHtmlTags(entity.description), spacing: { after: 200 } })] : []),
+                ...(entityClaims.length > 0 ? [
+                  new Paragraph({ text: 'Claims', heading: HeadingLevel.HEADING_2 }),
+                  ...entityClaims.map(claim => new Paragraph({
+                    text: `• ${stripHtmlTags(claim.statement)}${claim.confidence !== 1 ? ` (confidence: ${Math.round(claim.confidence * 100)}%)` : ''}`,
+                    spacing: { after: 100 },
+                  })),
+                ] : []),
+              ];
+            }),
           ],
         }],
       });

--- a/src/lib/export-core.ts
+++ b/src/lib/export-core.ts
@@ -3,10 +3,33 @@ import type { Entity, Claim, Note, Link } from './validation';
 
 export interface ExportData {
   entities: Entity[];
-  claims: Record<string, Claim[]>;
-  notes: Record<string, Note[]>;
+  claims: Record<string, Claim[] | undefined>;
+  notes: Record<string, Note[] | undefined>;
   links?: Link[];
   exported_at?: string;
+}
+
+export interface ExportRepository {
+  getAllEntities(): Promise<Entity[]>;
+  getAllLinks(): Promise<Link[]>;
+  getAllClaimsGroupedByEntity(): Promise<Record<string, Claim[]>>;
+  getAllNotesGroupedByEntity(): Promise<Record<string, Note[]>>;
+}
+
+export async function fetchAllExportData(repository: ExportRepository): Promise<Required<ExportData>> {
+  const [entities, links, claims, notes] = await Promise.all([
+    repository.getAllEntities(),
+    repository.getAllLinks(),
+    repository.getAllClaimsGroupedByEntity(),
+    repository.getAllNotesGroupedByEntity(),
+  ]);
+  return {
+    entities,
+    links,
+    claims,
+    notes,
+    exported_at: new Date().toISOString(),
+  };
 }
 
 export function generateSiteHtml(data: ExportData): string {


### PR DESCRIPTION
## Summary

Deduplicates export logic between ExportPanel.tsx and CLI:

- **`fetchAllExportData()`**: New shared function in `export-core.ts` that wraps the 4 repository calls (`getAllEntities`, `getAllLinks`, `getAllClaimsGroupedByEntity`, `getAllNotesGroupedByEntity`) in a single `Promise.all`
- **ExportPanel.tsx**: Replaced 5 separate data-fetching blocks with single `fetchAllExportData(repository)` calls. Fixed site export to include full notes instead of empty `{}`
- **cli/index.ts**: Replaced 3 separate data-fetching blocks with `fetchAllExportData(repository)`. Eliminated N+1 query problem in markdown export by fetching all claims/notes upfront

Closes #191