### PR TITLE
Virtualize Editor Mention Menu and Clean Up Duplicated JSX

### DIFF
--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -53,9 +53,10 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
 
   useEffect(() => {
     if (status) {
-      const timer = setTimeout(() => setStatus(null), 5000);
-      return () => clearTimeout(timer);
+      const timer = setTimeout(() => { setStatus(null); }, 5000);
+      return () => { clearTimeout(timer); };
     }
+    return undefined;
   }, [status]);
 
   useEffect(() => {
@@ -74,13 +75,13 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
       if (!entity) return;
       setTitle(entity.name || '');
       setType(entity.type);
-      setSourceUrl(entity.sourceUrl ?? '');
+      setSourceUrl(typeof entity.sourceUrl === 'string' ? entity.sourceUrl : '');
       setShowAdvanced(entity.metadata?.advanced ?? false);
       setStatus(null);
-    }).catch(err => logger.error('Failed to load entity for editing', err))
-    .finally(() => setIsLoadingEntity(false));
+    }).catch(err => { logger.error('Failed to load entity for editing', err); })
+    .finally(() => { setIsLoadingEntity(false); });
 
-    repository.getBacklinks(editingEntityId).then(setBacklinks).catch(err => logger.error('Failed to load backlinks', err));
+    repository.getBacklinks(editingEntityId).then(setBacklinks).catch(err => { logger.error('Failed to load backlinks', err); });
   }, [editingEntityId]);
 
   const handleTypeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -105,7 +106,7 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
         // Update existing entity
         const entity = await repository.updateEntity(editingEntityId, {
           name: title,
-          type: type,
+          type,
           description: content,
         });
 
@@ -119,16 +120,16 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
         // Create new entity
         const entity = await repository.createEntity({
           name: title,
-          type: type,
+          type,
           description: content,
           metadata: {}
         });
 
         // Enqueue external URL fetch for auto-hydration if source URL provided
-        if (sourceUrl.trim()) {
+        if (sourceUrl.trim() && entity.id) {
           jobCoordinator.enqueue('external-fetch', entity.id, {
             url: sourceUrl.trim(),
-            entityId: entity.id!,
+            entityId: entity.id,
           });
           logger.info('Enqueued external fetch for entity auto-hydration', { entityId: entity.id, url: sourceUrl });
         }
@@ -159,25 +160,27 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
 
         const statements: { sql: string; bind?: (string | number | boolean | null)[] }[] = [];
 
-        statements.push({
-          sql: `INSERT INTO notes (entity_id, content, format) VALUES (?, ?, ?)`,
-          bind: [entity.id, content, 'markdown']
-        });
-
-        for (const claim of claims) {
+        if (entity.id) {
           statements.push({
-            sql: `INSERT INTO claims (entity_id, statement, confidence, evidence, source, verification_status)
-                  VALUES (?, ?, ?, ?, ?, ?)`,
-            bind: [entity.id!, claim.statement, 1.0, 'Extracted from editor', claim.source, claim.status]
+            sql: 'INSERT INTO notes (entity_id, content, format) VALUES (?, ?, ?)',
+            bind: [entity.id, content, 'markdown']
           });
-        }
 
-        for (const mention of mentions) {
-          statements.push({
-            sql: `INSERT INTO links (source_id, target_id, relation, metadata)
-                  VALUES (?, ?, ?, ?)`,
-            bind: [entity.id!, mention.id, 'mentions', JSON.stringify({ name: mention.name })]
-          });
+          for (const claim of claims) {
+            statements.push({
+              sql: `INSERT INTO claims (entity_id, statement, confidence, evidence, source, verification_status)
+                    VALUES (?, ?, ?, ?, ?, ?)`,
+              bind: [entity.id, claim.statement, 1.0, 'Extracted from editor', claim.source, claim.status]
+            });
+          }
+
+          for (const mention of mentions) {
+            statements.push({
+              sql: `INSERT INTO links (source_id, target_id, relation, metadata)
+                    VALUES (?, ?, ?, ?)`,
+              bind: [entity.id, mention.id, 'mentions', JSON.stringify({ name: mention.name })]
+            });
+          }
         }
 
         if (statements.length > 0) {
@@ -281,7 +284,7 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
             <CheckCircle size={16} aria-hidden="true" /> Claim
           </button>
           <div className="toolbar-spacer" />
-        <button type="button" onClick={() => void handleSave()} className="primary">{editingEntityId ? 'Update Entity' : 'Save to DB'}</button>
+        <button type="button" onClick={() => { void handleSave(); }} className="primary">{editingEntityId ? 'Update Entity' : 'Save to DB'}</button>
         {editingEntityId && (
           <button type="button" onClick={handleCancelEdit} aria-label="Cancel editing">
             Cancel
@@ -322,7 +325,7 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
             {backlinks.map(bl => (
               <button
                 key={bl.id}
-                onClick={() => onEditEntity?.(bl.id!)}
+                onClick={() => { if (bl.id) onEditEntity?.(bl.id); }}
                 className="backlink-chip"
                 style={{
                   padding: '4px 10px',
@@ -373,7 +376,7 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
        )}
        {showAdvanced && showMentionMenu && (
          <div className="mention-section" style={{ marginTop: '16px' }}>
-           <label className="block text-sm font-medium mb-2">Link to Entity</label>
+           <h4 className="block text-sm font-medium mb-2">Link to Entity</h4>
            <div
              ref={mentionScrollRef}
              className="space-y-2"

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -374,49 +374,42 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete, onEdit
        {showAdvanced && showMentionMenu && (
          <div className="mention-section" style={{ marginTop: '16px' }}>
            <label className="block text-sm font-medium mb-2">Link to Entity</label>
-           <div className="space-y-2">
-             {allEntities.map(entity => (
-               <button
-                 key={entity.id}
-                 onClick={() => {
-                   insertMention(entity);
-                   setShowMentionMenu(false);
-                 }}
-                 className="mention-item w-full text-left px-3 py-2 rounded border border-muted hover:bg-muted"
-               >
-                 {entity.name} ({entity.type})
-               </button>
-             ))}
-           </div>
-         </div>
-       )}
-       {editingEntityId && backlinks.length > 0 && (
-         <div className="backlinks-section" style={{ marginTop: '24px', paddingTop: '16px', borderTop: '1px solid var(--border-default)' }}>
-           <h4 style={{ fontSize: '13px', fontWeight: 600, color: 'var(--text-muted)', marginBottom: '12px', display: 'flex', alignItems: 'center', gap: '6px' }}>
-             <Link2 size={14} /> Referenced by ({backlinks.length})
-           </h4>
-           <div className="backlinks-list" style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-             {backlinks.map(bl => (
-               <button
-                 key={bl.id}
-                 onClick={() => onEditEntity?.(bl.id!)}
-                 className="backlink-chip"
-                 style={{
-                   padding: '4px 10px',
-                   borderRadius: '16px',
-                   background: 'var(--background-secondary)',
-                   border: '1px solid var(--border-default)',
-                   fontSize: '12px',
-                   cursor: 'pointer',
-                   color: 'var(--interactive-primary)',
-                   display: 'flex',
-                   alignItems: 'center',
-                   gap: '4px'
-                 }}
-               >
-                 <AtSign size={10} /> {bl.name}
-               </button>
-             ))}
+           <div
+             ref={mentionScrollRef}
+             className="space-y-2"
+             style={{ height: '240px', overflow: 'auto', position: 'relative' }}
+           >
+             <div
+               style={{
+                 height: `${mentionVirtualizer.getTotalSize()}px`,
+                 width: '100%',
+                 position: 'relative',
+               }}
+             >
+               {mentionVirtualizer.getVirtualItems().map((virtualItem) => {
+                 const entity = allEntities[virtualItem.index];
+                 return (
+                   <button
+                     key={virtualItem.key}
+                     onClick={() => {
+                       insertMention(entity);
+                       setShowMentionMenu(false);
+                     }}
+                     className="mention-item w-full text-left px-3 py-2 rounded border border-muted hover:bg-muted"
+                     style={{
+                       position: 'absolute',
+                       top: 0,
+                       left: 0,
+                       width: '100%',
+                       height: `${virtualItem.size}px`,
+                       transform: `translateY(${virtualItem.start}px)`,
+                     }}
+                   >
+                     {entity.name} ({entity.type})
+                   </button>
+                 );
+               })}
+             </div>
            </div>
          </div>
        )}


### PR DESCRIPTION
Virtualizes the entity mention menu in the Editor component and removes a duplicated backlinks section. Verified with unit tests and manual code inspection. Temporary verification artifacts were cleaned up prior to submission.

---
*PR created automatically by Jules for task [5537872564933547366](https://jules.google.com/task/5537872564933547366) started by @d-oit*