### PR TITLE
feat(ux): add clear button to CommandPalette search input

### DIFF
--- a/agents-docs/MAINTENANCE.md
+++ b/agents-docs/MAINTENANCE.md
@@ -25,6 +25,23 @@ The following PRs from `d-oit/do-knowledge-studio` were validated and integrated
 ### Recommendation
 Close all the above PRs (2-8, 10) as they have been manually consolidated into the current branch to ensure compatibility and atomic verification.
 
+## 2026-06-05: PR #263 Review Fixes
+
+| PR # | Title | Status | Notes |
+|------|-------|--------|-------|
+| 263 | feat(ux): add clear button to CommandPalette search input | Review fixes applied | Jules-generated PR with 3 review issues (DeepSource + Codacy). |
+
+### Review Comments Resolved
+- **DeepSource (2 comments):** `isOpen={true}` → `isOpen` JSX boolean shorthand in test file.
+- **Codacy BestPractice (high):** Added explicit `type="button"` to clear button in `CommandPalette.tsx`.
+- **Codacy Security (high):** Fixed overlay `role="button"` keyboard handler — added `Enter`/`Space`/`Escape` support with `e.target === e.currentTarget` guard to prevent event bubbling from child inputs.
+
+### Commit
+- `78bb75c` on `feat/palette-clear-button-1216242682040609131`
+
 ## Learnings
 - **Vite 8 Upgrade**: Upgrading Vite to major version 8 requires checking compatibility of companion plugins like `@vitejs/plugin-react` and the test runner `vitest`. Peer dependency warnings should be resolved by moving to the latest stable versions of these dependencies.
 - **SHA-based Workflows**: Many workflows use commit SHAs for security. When updating these via Dependabot PRs, ensure both the SHA and the trailing version comment are updated for clarity.
+- **JSX Boolean Attributes**: Always use shorthand (`<Foo bar />`) instead of `bar={true}` for boolean props. DeepSource flags explicit `true` values.
+- **Button Type Attribute**: Every `<button>` must have an explicit `type` attribute (`"button"`, `"submit"`, or `"reset"`). Codacy flags missing types as BestPractice violations.
+- **role="button" Keyboard Support**: Elements with `role="button"` must handle `Enter`, `Space`, and `Escape` keyboard events. Use `e.target === e.currentTarget` guard to prevent event bubbling from child elements (e.g., search inputs). Without the guard, typing a space in an input inside a `role="button"` container will trigger the close/submit action.

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -129,7 +129,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, onView
     <div
       className="command-palette-overlay"
       onClick={handleOverlayClick}
-      onKeyDown={e => e.key === 'Escape' && onClose()}
+      onKeyDown={e => { if (e.target === e.currentTarget && (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ')) onClose(); }}
       role="button"
       tabIndex={0}
       aria-label="Close command palette"
@@ -157,6 +157,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, onView
           />
           {query && (
             <button
+              type="button"
               className="input-clear-button"
               onClick={() => { setQuery(''); inputRef.current?.focus(); }}
               aria-label="Clear search"

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -9,7 +9,8 @@ import {
   Map,
   Plus,
   Download,
-  Command
+  Command,
+  X
 } from 'lucide-react';
 import { searchKnowledge, SearchResult } from '../lib/search';
 import { logger } from '../lib/logger';
@@ -142,7 +143,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, onView
           <Search className="search-icon" size={20} />
           <input
             ref={inputRef}
-            type="text"
+            type="search"
             placeholder="Search commands or knowledge..."
             value={query}
             onChange={e => setQuery(e.target.value)}
@@ -154,6 +155,15 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose, onView
             aria-controls="command-palette-listbox"
             aria-activedescendant={totalItems > 0 ? `command-item-${selectedIndex}` : undefined}
           />
+          {query && (
+            <button
+              className="input-clear-button"
+              onClick={() => { setQuery(''); inputRef.current?.focus(); }}
+              aria-label="Clear search"
+            >
+              <X size={16} />
+            </button>
+          )}
           <div className="esc-hint">ESC</div>
         </div>
 

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -21,7 +21,7 @@ describe('CommandPalette', () => {
   it('renders when isOpen is true', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -45,7 +45,7 @@ describe('CommandPalette', () => {
   it('calls onClose when Escape is pressed', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -59,7 +59,7 @@ describe('CommandPalette', () => {
   it('calls onClose when clicking the overlay', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -78,7 +78,7 @@ describe('CommandPalette', () => {
 
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -98,7 +98,7 @@ describe('CommandPalette', () => {
   it('navigates through commands with ArrowDown/ArrowUp', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -123,7 +123,7 @@ describe('CommandPalette', () => {
   it('executes a navigation command on Enter', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -142,7 +142,7 @@ describe('CommandPalette', () => {
   it('executes an action command on Enter', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -163,7 +163,7 @@ describe('CommandPalette', () => {
   it('shows clear button when input has text', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}
@@ -180,7 +180,7 @@ describe('CommandPalette', () => {
   it('clears input and refocuses when clear button is clicked', () => {
     render(
       <CommandPalette
-        isOpen={true}
+        isOpen
         onClose={mockOnClose}
         onViewChange={mockOnViewChange}
         onAction={mockOnAction}

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -159,4 +159,41 @@ describe('CommandPalette', () => {
     expect(mockOnAction).toHaveBeenCalledWith('act-new');
     expect(mockOnClose).toHaveBeenCalled();
   });
+
+  it('shows clear button when input has text', () => {
+    render(
+      <CommandPalette
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewChange={mockOnViewChange}
+        onAction={mockOnAction}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/Search commands or knowledge/i);
+    expect(screen.queryByLabelText(/Clear search/i)).toBeNull();
+
+    fireEvent.change(input, { target: { value: 'test' } });
+    expect(screen.getByLabelText(/Clear search/i)).toBeDefined();
+  });
+
+  it('clears input and refocuses when clear button is clicked', () => {
+    render(
+      <CommandPalette
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewChange={mockOnViewChange}
+        onAction={mockOnAction}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/Search commands or knowledge/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'test' } });
+    const clearBtn = screen.getByLabelText(/Clear search/i);
+
+    fireEvent.click(clearBtn);
+
+    expect(input.value).toBe('');
+    expect(document.activeElement).toBe(input);
+  });
 });

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -39,6 +39,8 @@
 .command-palette-header .search-icon {
   color: var(--text-muted);
   flex-shrink: 0;
+  position: static;
+  pointer-events: auto;
 }
 
 .command-palette-header input {
@@ -49,6 +51,7 @@
   font-size: 1.1rem;
   color: var(--text-primary);
   padding: var(--space-1) 0;
+  padding-right: var(--space-2);
 }
 
 .command-palette-header .input-clear-button {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,6 +4,7 @@
 @import './layout.css';
 @import './components.css';
 @import './features.css';
+@import './command-palette.css';
 @import './utilities.css';
 
 /* Global Typography Overrides */


### PR DESCRIPTION
I have implemented a micro-UX improvement by adding a "Clear" button to the CommandPalette search input. This enhancement allows users to quickly reset their search query and refocus the input, making the command-first interface more pleasant and efficient to use. 

Key changes:
- Logic: Added state-based visibility for the clear button and a refocusing handler in `CommandPalette.tsx`.
- Accessibility: Changed the input type to `search`, providing better context for screen readers and specialized mobile keyboards.
- Styling: Imported `command-palette.css` into the main stylesheet and refined header layout to ensure visual consistency and prevent icon overlap.
- Verification: Added new Vitest test cases and performed visual verification using Playwright to ensure the button behaves correctly and looks great.

---
*PR created automatically by Jules for task [1216242682040609131](https://jules.google.com/task/1216242682040609131) started by @d-oit*