### PR TITLE
fix: resolve E2E test failures — nested transaction + tiptap timing

### DIFF
--- a/src/db/db-worker.ts
+++ b/src/db/db-worker.ts
@@ -161,6 +161,16 @@ self.onmessage = async (event: MessageEvent) => {
 
         const { statements } = payload as TransactionPayload;
 
+        // Clear any dangling transaction state from a prior exec() with
+        // RETURNING — SQLite WASM's oo1.DB.exec can leave autocommit off
+        // after INSERT…RETURNING with returnValue:'resultRows'.
+        try { db.exec('COMMIT;'); } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (!msg.includes('no transaction is active')) {
+            throw err; // Unexpected error — rethrow
+          }
+        }
+
         db.exec('BEGIN TRANSACTION;');
         try {
           const results = [];

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -328,8 +328,9 @@ test.describe('Entity Editor with Source URL', () => {
     const sourceInput = page.locator('#entity-source-url');
     await sourceInput.fill('https://example.com/persisted-article');
 
-    // Wait for tiptap editor to initialize before saving
+    // Wait for tiptap editor to fully initialize (useEditor hook returns non-null)
     await expect(page.locator('.tiptap-content')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.tiptap-content .ProseMirror[contenteditable="true"]')).toBeVisible({ timeout: 5000 });
 
     // Save entity
     const saveBtn = page.locator('button.primary', { hasText: 'Save to DB' });

--- a/tests/e2e/library.spec.ts
+++ b/tests/e2e/library.spec.ts
@@ -16,8 +16,9 @@ test.describe('Library View', () => {
 
     await page.fill('input[placeholder="Entity Name (e.g. TRIZ)"]', 'Library Test Entity');
     await page.selectOption('select', 'concept');
-    // Wait for tiptap editor to initialize before saving
+    // Wait for tiptap editor to fully initialize (useEditor hook returns non-null)
     await expect(page.locator('.tiptap-content')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.tiptap-content .ProseMirror[contenteditable="true"]')).toBeVisible({ timeout: 5000 });
     await page.click('button:has-text("Save to DB")');
     await expect(page.locator('[role="alert"]')).toContainText('Saved successfully', { timeout: 10000 });
   });


### PR DESCRIPTION
## Summary

Fixes all 4 previously failing E2E tests.

### Changes
- **db-worker.ts**: Defensive `COMMIT` before `BEGIN TRANSACTION` with narrowed catch clause. Fixes SQLite WASM quirk where `INSERT...RETURNING` with `returnValue:"resultRows"` leaves autocommit off.
- **library.spec.ts, features.spec.ts**: Wait for `.ProseMirror[contenteditable="true"]` instead of `.tiptap-content` visibility. Ensures `useEditor` hook has resolved before clicking Save.

### Validation
- 19/19 E2E tests pass ✅
- 310/310 unit tests pass ✅
- Lint clean ✅
- Typecheck clean ✅

Co-authored-by: d-oit <6849456+d-oit@users.noreply.github.com>