### PR TITLE
fix(tests): stabilize flaky command palette E2E test

### DIFF
--- a/tests/e2e/modern-shell.spec.ts
+++ b/tests/e2e/modern-shell.spec.ts
@@ -13,19 +13,21 @@ test.describe('Modern Shell UX', () => {
     // Toggle on
     await page.keyboard.press('Control+k');
     await expect(palette).toBeVisible();
+    // Wait for input focus (palette uses setTimeout 10ms to focus input)
+    await expect(page.locator('.command-palette-header input')).toBeFocused({ timeout: 3000 });
 
     // Toggle off with Escape
     await page.keyboard.press('Escape');
-    await expect(palette).not.toBeVisible();
+    await expect(palette).not.toBeVisible({ timeout: 5000 });
 
     // Toggle on again
     await page.keyboard.press('Control+k');
     await expect(palette).toBeVisible();
+    await expect(page.locator('.command-palette-header input')).toBeFocused({ timeout: 3000 });
 
     // Toggle off by clicking overlay
-    // Use dispatchEvent for more reliable overlay clicks across viewports
     await page.locator('.command-palette-overlay').evaluate(el => (el as HTMLElement).click());
-    await expect(palette).not.toBeVisible();
+    await expect(palette).not.toBeVisible({ timeout: 5000 });
   });
 
   test('searching and keyboard navigation in palette', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes the flaky Cmd+K command palette E2E test (~1/3 failure rate).

### Root Cause
CommandPalette opens with `setTimeout(() => inputRef.current?.focus(), 10)`. The test pressed Escape immediately after `toBeVisible()`, but the input may not have focus yet. Escape then goes to the body instead of the input handleKeyDown.

### Fix
Added `toBeFocused({ timeout: 3000 })` after each palette open to ensure focus before pressing Escape.

### Validation
- 5/5 consecutive runs pass ✅ (was ~1/3 failure)
- Lint clean ✅
- 310 unit tests ✅

Co-authored-by: d-oit <6849456+d-oit@users.noreply.github.com>