### PR TITLE
docs: enforce automated releases via version-propagation workflow

### DIFF
--- a/.agents/tasks/release-branch.md
+++ b/.agents/tasks/release-branch.md
@@ -41,16 +41,11 @@ You are preparing a release branch for this project. Follow these steps systemat
    pnpm run build && pnpm run preview
    ```
 
-## Phase 3 — Tag & Push
+## Phase 3 — Push Branch
 
-1. Create annotated tag:
-   ```bash
-   git tag -a "vX.Y.Z" -m "Release vX.Y.Z"
-   ```
-2. Push branch and tags:
+1. Push the release branch (tagging is handled by the version-propagation workflow after merge):
    ```bash
    git push -u origin release/vX.Y.Z
-   git push origin vX.Y.Z
    ```
 
 ## Phase 4 — GitHub Release
@@ -59,16 +54,16 @@ You are preparing a release branch for this project. Follow these steps systemat
    ```bash
    gh pr create --base main --title "Release vX.Y.Z" --body "$(cat CHANGELOG.md | sed -n '/## vX.Y.Z/,/## v/p' | head -n -1)"
    ```
-2. After merge, create the GitHub Release:
-   ```bash
-   gh release create "vX.Y.Z" --title "vX.Y.Z" --notes-file - <<< "$CHANGELOG_CONTENT"
-   ```
+2. After merge, the version-propagation workflow handles everything:
+   - `.github/workflows/version-propagation.yml` triggers on `VERSION` change
+   - Runs `scripts/propagate-version.sh` to sync version across all files
+   - Tags the release automatically
 
 ## Phase 5 — Post-release
 
-1. Verify the release is published:
+1. Verify CI passed on main after the version bump merge:
    ```bash
-   gh release view vX.Y.Z
+   gh run list --branch main --limit 3
    ```
 2. Update `plans/` with release notes.
 3. Announce in relevant channels.
@@ -77,5 +72,6 @@ You are preparing a release branch for this project. Follow these steps systemat
 
 - **Never** skip the quality gate.
 - **Never** release without passing all CI checks.
+- **Never** create GitHub releases manually (`gh release create`). Use the version-propagation workflow.
 - **Always** use semantic versioning.
 - **Always** tag releases with `v` prefix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Local-first knowledge studio with rich text, knowledge graph, mind maps, SQLite 
 - Prefer small, composable modules over mixed-responsibility files.
 - Reuse existing abstractions before introducing new patterns.
 - Keep changes scoped; avoid unrelated refactors in the same commit.
+- **Never** create GitHub releases manually (`gh release create`). Releases are handled by `.github/workflows/version-propagation.yml` — edit `VERSION` and the workflow propagates and tags automatically.
 
 ## Repository Shape
 

--- a/agents-docs/VERSION.md
+++ b/agents-docs/VERSION.md
@@ -64,8 +64,18 @@ If a new file needs version references:
 2. Add appropriate `sed` patterns for the file's version format
 3. Update this documentation
 
+## Release Workflow
+
+GitHub releases are **fully automated** via `.github/workflows/version-propagation.yml`. Do NOT create releases manually with `gh release create`. The workflow:
+
+1. Triggers on push to `VERSION` file on `main` or `feat/**`
+2. Runs `scripts/propagate-version.sh` to sync version strings
+3. Commits and pushes any remaining updates
+4. Tags the release automatically
+
 ## Lessons
 
 - Never manually edit version strings in multiple files — always use `VERSION` + propagate
+- Never use `gh release create` — the version-propagation workflow handles releases
 - The pre-commit hook re-stages propagated files automatically (`git add`)
 - CI workflow is a safety net for missed propagations


### PR DESCRIPTION
## Summary

Documents and enforces that GitHub releases are fully automated via `.github/workflows/version-propagation.yml`. Manual `gh release create` is now explicitly forbidden.

### Changes
- **AGENTS.md**: Added hard rule in Hard Rules section
- **.agents/tasks/release-branch.md**: Removed manual git tag and gh release commands, added concrete CI verification command
- **agents-docs/VERSION.md**: Added Release Workflow section and lesson

Co-authored-by: d-oit <6849456+d-oit@users.noreply.github.com>