### PR TITLE
ci: enforce E2E tests in pipeline + update README for v0.2.5

### DIFF
--- a/.github/workflows/ci-and-labels.yml
+++ b/.github/workflows/ci-and-labels.yml
@@ -115,7 +115,6 @@ jobs:
     timeout-minutes: 30
     needs: [changes, quality-gate, unit-tests]
     if: needs.changes.outputs.any_code == 'true'
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first knowledge management studio — rich notes, knowledge graph, mind maps, full-text search, and AI agent integration in a single browser-based app.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.1.0-blue)](VERSION)
+[![Version](https://img.shields.io/badge/version-0.2.5-blue)](VERSION)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Built with React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript)](https://www.typescriptlang.org)
@@ -35,8 +35,9 @@ This project is in active development. See [PHASES.md](docs/PHASES.md) for progr
 - **📤 Static Site Export** — Turn your knowledge base into a shareable, self-contained static site (Markdown, JSON, HTML)
 - **🤖 AI Agent Harness** — Unified workflow across 6+ AI coding tools with skills, quality gates, and sub-agent patterns
 - **🔬 Swarm Analysis** — Parallel AI-powered web research using git worktrees
-- **⚡ CLI** — TypeScript CLI for scripting and automation tasks
-- **🧪 Full Test Suite** — Vitest unit tests + Playwright end-to-end tests
+- **🔒 AES-256-GCM Encryption** — API keys encrypted at rest via Web Crypto API
+- **⚡ CLI** — TypeScript CLI with 20 commands for scripting and automation
+- **🧪 Full Test Suite** — 310 Vitest unit tests + 31 Playwright end-to-end tests
 
 ---
 
@@ -256,6 +257,12 @@ See [SETUP.md](docs/SETUP.md) for detailed CLI instructions and how to connect t
 - 🔄 **[Migration](agents-docs/MIGRATION.md)** — Adopting in existing projects
 - 🔒 **[Security](SECURITY.md)** — Security policy and reporting
 - 📝 **[Changelog](CHANGELOG.md)** — Release history
+- 🔧 **[CLI Reference](docs/CLI.md)** — All 20 CLI commands
+- 🗄️ **[Database Schema](docs/DATABASE.md)** — Tables, ER diagram, migrations
+- 🔍 **[Search Architecture](docs/SEARCH.md)** — Dual FTS5 + Orama search
+- 🤖 **[LLM Setup](docs/LLM-SETUP.md)** — Provider configuration
+- 📦 **[Repository API](docs/REPOSITORY-API.md)** — Full API reference
+- 👩‍💻 **[Developer Guide](docs/DEVELOPMENT.md)** — Onboarding and common tasks
 
 ---
 


### PR DESCRIPTION
## Summary

E2E tests are now stable (31/31 pass). Removed `continue-on-error: true` so E2E failures block the pipeline.

Also updated README.md with v0.2.5 features and new documentation links.

### Changes
- **ci-and-labels.yml**: Removed `continue-on-error: true` from e2e-tests job
- **README.md**: Version badge 0.2.5, AES-256-GCM feature, CLI/test counts, 7 new doc links

Co-authored-by: d-oit <6849456+d-oit@users.noreply.github.com>