### PR TITLE
Harden Export Security and Mitigate Tabnabbing

### DIFF
--- a/src/features/export/ExportPanel.tsx
+++ b/src/features/export/ExportPanel.tsx
@@ -80,6 +80,7 @@ const ExportPanel: React.FC = () => {
       const data = await fetchAllExportData(repository);
       const printWindow = window.open('', '_blank');
       if (!printWindow) throw new Error('Popup blocked');
+      printWindow.opener = null;
       const printDoc = printWindow.document;
       printDoc.open();
       printDoc.write(generatePrintHtml(data.entities, data.claims));

--- a/src/lib/export-core.ts
+++ b/src/lib/export-core.ts
@@ -49,7 +49,7 @@ export function generateSiteHtml(data: ExportData): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; img-src 'self' data:; script-src 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; img-src 'self' data:; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';">
   <title>Knowledge Base</title>
   <style>
     body { font-family: system-ui, -apple-system, sans-serif; max-width: 900px; margin: 0 auto; padding: 2rem; line-height: 1.6; color: #1e293b; background: #f8fafc; }
@@ -188,7 +188,7 @@ export function generatePrintHtml(entities: Entity[], claims: Record<string, Cla
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; img-src 'self' data:; script-src 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; img-src 'self' data:; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';">
   <title>Knowledge Base Export</title>
   <style>
     body { font-family: system-ui, -apple-system, sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; line-height: 1.6; color: #1e293b; }


### PR DESCRIPTION
This change implements two concrete security enhancements for the application's export functionality:

1.  **Harden Content Security Policy (CSP) for HTML Exports**: Updated `generateSiteHtml` and `generatePrintHtml` in `src/lib/export-core.ts` to include `object-src 'none'`, `base-uri 'none'`, and `form-action 'none'`. This significantly reduces the attack surface of exported knowledge bases by preventing plugin execution, `<base>` tag hijacking, and unauthorized form submissions.
2.  **Mitigate Tabnabbing in PDF Export**: Updated the `handleExportPDF` function in `src/features/export/ExportPanel.tsx` to set `printWindow.opener = null` when opening the print popup. This prevents the newly opened window from accessing or manipulating the original application window via the `window.opener` property.

These changes align with 2026 security best practices for local-first applications and static data exports. All tests passed, and frontend verification confirmed no regressions in the export flow.

---
*PR created automatically by Jules for task [10640798830242734631](https://jules.google.com/task/10640798830242734631) started by @d-oit*