### PR TITLE
perf(editor): virtualize entity mention list

### DIFF
--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import { ClaimExtension } from './ClaimExtension';
@@ -31,6 +32,14 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete }) => {
   const [sourceUrl, setSourceUrl] = useState('');
   const [allEntities, setAllEntities] = useState<Entity[]>([]);
   const [showMentionMenu, setShowMentionMenu] = useState(false);
+  const mentionScrollRef = useRef<HTMLDivElement>(null);
+
+  const mentionVirtualizer = useVirtualizer({
+    count: allEntities.length,
+    getScrollElement: () => mentionScrollRef.current,
+    estimateSize: () => 48,
+    overscan: 5,
+  });
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [status, setStatus] = useState<{ type: 'success' | 'error', message: string } | null>(null);
   const [isLoadingEntity, setIsLoadingEntity] = useState(false);
@@ -335,19 +344,47 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete }) => {
        {showAdvanced && showMentionMenu && (
          <div className="mention-section" style={{ marginTop: '16px' }}>
            <h4 className="block text-sm font-medium mb-2">Link to Entity</h4>
-           <div className="space-y-2">
-             {allEntities.map(entity => (
-               <button
-                 key={entity.id}
-                 onClick={() => {
-                   insertMention(entity);
-                   setShowMentionMenu(false);
-                 }}
-                 className="mention-item w-full text-left px-3 py-2 rounded border border-muted hover:bg-muted"
-               >
-                 {entity.name} ({entity.type})
-               </button>
-             ))}
+           <div
+             ref={mentionScrollRef}
+             className="mention-list-container"
+             style={{
+               maxHeight: '300px',
+               overflowY: 'auto',
+               position: 'relative',
+             }}
+           >
+             <div
+               style={{
+                 height: `${mentionVirtualizer.getTotalSize()}px`,
+                 width: '100%',
+                 position: 'relative',
+               }}
+             >
+               {mentionVirtualizer.getVirtualItems().map((virtualItem) => {
+                 const entity = allEntities[virtualItem.index];
+                 if (!entity) return null;
+                 return (
+                   <button
+                     key={virtualItem.key}
+                     onClick={() => {
+                       insertMention(entity);
+                       setShowMentionMenu(false);
+                     }}
+                     className="mention-item w-full text-left px-3 py-2 rounded border border-muted hover:bg-muted"
+                     style={{
+                       position: 'absolute',
+                       top: 0,
+                       left: 0,
+                       width: '100%',
+                       height: `${virtualItem.size - 8}px`,
+                       transform: `translateY(${virtualItem.start}px)`,
+                     }}
+                   >
+                     {entity.name} ({entity.type})
+                   </button>
+                 );
+               })}
+             </div>
            </div>
          </div>
        )}

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -362,7 +362,6 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete }) => {
              >
                {mentionVirtualizer.getVirtualItems().map((virtualItem) => {
                  const entity = allEntities[virtualItem.index];
-                 if (!entity) return null;
                  return (
                    <button
                      key={virtualItem.key}


### PR DESCRIPTION
This PR implements virtualization for the entity mention list in the Editor component. 

### Performance Improvement
- Replaced the flat rendering of `allEntities` with `useVirtualizer`.
- Reduced DOM nodes from O(N) to O(1) during mention menu interactions.
- Added a 300px fixed-height scroll container for mentions.

### UI Consistency
- Maintained the 8px vertical gap between items by adjusting `estimateSize` and item `height`.
- Verified the fix via Playwright screenshots with sample data.

### Quality
- Passed `pnpm run typecheck` and `pnpm run test`.
- Addressed code review feedback regarding styling regressions.

---
*PR created automatically by Jules for task [16727545484266544797](https://jules.google.com/task/16727545484266544797) started by @d-oit*