### PR TITLE
feat: implement deferred plan items — undo/redo, LLM chat, semantic toggle, claim reconciliation

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -222,7 +222,6 @@ const AppContent: React.FC = () => {
                 <Profiled id="MindMapView">
                   <MindMapView
                     rootEntity={entities[0]}
-                    relatedEntities={entities.slice(1, 10)}
                     entities={entities}
                     links={links}
                   />

--- a/src/features/chat/Chat.tsx
+++ b/src/features/chat/Chat.tsx
@@ -1,8 +1,10 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { searchKnowledge } from '../../lib/search';
 import { type RankedResult } from '../../db/repository';
 import { logger } from '../../lib/logger';
-import { Search, Send, ChevronDown, ChevronUp, Database, ShieldCheck, Loader2 } from 'lucide-react';
+import { loadConfig, createProvider } from '../../lib/llm/config';
+import type { LLMMessage } from '../../lib/llm/types';
+import { Search, Send, ChevronDown, ChevronUp, Database, ShieldCheck, Loader2, Sparkles } from 'lucide-react';
 
 interface Message {
   id: string;
@@ -80,28 +82,40 @@ function ChatMessage({ message, showSources, onToggleSources, onNavigate }: Chat
   );
 }
 
+const SYSTEM_PROMPT = 'You are a helpful knowledge assistant for Knowledge Studio. Ground your answers in the provided local context whenever possible. Be concise and cite specific entities or claims when relevant.';
+
 function Chat({ onCreateEntity, onNavigate }: ChatProps): React.ReactElement {
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState<Message[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [showSources, setShowSources] = useState<Record<string, boolean>>({});
+  const [llmAvailable, setLlmAvailable] = useState(false);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const messagesRef = useRef(messages);
 
-  function canSend(currentInput: string): boolean {
-    return currentInput.trim() !== '' && !isSearching && !debounceRef.current;
-  }
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
-  function scheduleDebounceReset() {
-    debounceRef.current = setTimeout(() => { debounceRef.current = null; }, 300);
-  }
+  useEffect(() => {
+    void (async () => {
+      try {
+        const config = await loadConfig();
+        const provider = createProvider(config);
+        setLlmAvailable(provider.isConfigured());
+      } catch {
+        setLlmAvailable(false);
+      }
+    })();
+  }, []);
 
-  async function handleSend(e?: React.FormEvent, query?: string) {
+  const handleSend = useCallback(async (e?: React.FormEvent, query?: string) => {
     e?.preventDefault();
     const currentInput = query ?? input;
-    if (!canSend(currentInput)) return;
+    if (currentInput.trim() === '' || isSearching || debounceRef.current) return;
 
-    scheduleDebounceReset();
+    debounceRef.current = setTimeout(() => { debounceRef.current = null; }, 300);
     const userId = `user-${Date.now()}`;
     setMessages(prev => [...prev, { id: userId, role: 'user', content: currentInput }]);
     setInput('');
@@ -109,28 +123,66 @@ function Chat({ onCreateEntity, onNavigate }: ChatProps): React.ReactElement {
 
     try {
       const results = await searchKnowledge(currentInput, { limit: 5 });
-      const assistantId = `assistant-${Date.now()}`;
-      setMessages(prev => [...prev, {
-        id: assistantId,
-        role: 'assistant',
-        content: buildResponse(currentInput, results),
-        citations: results
-      }]);
+
+      if (llmAvailable) {
+        const config = await loadConfig();
+        const provider = createProvider(config);
+        const providerConfig = config.providers[config.activeProvider];
+        const model = providerConfig.defaultModel || 'google/gemini-2.0-flash-lite-preview-02-05:free';
+
+        const contextBlock = results.length > 0
+          ? '\n\nRelevant local context:\n' + results.map(r => `[${r.type}] ${r.title}: ${r.content.slice(0, 200)}`).join('\n')
+          : '';
+
+        const historyMessages: LLMMessage[] = messagesRef.current.slice(-6).map(m => ({
+          role: m.role === 'user' ? 'user' as const : 'assistant' as const,
+          content: m.content,
+        }));
+
+        const promptMessages: LLMMessage[] = [
+          { role: 'system', content: SYSTEM_PROMPT },
+          ...historyMessages,
+          { role: 'user', content: currentInput + contextBlock },
+        ];
+
+        const assistantId = `assistant-${Date.now()}`;
+        setMessages(prev => [...prev, { id: assistantId, role: 'assistant', content: '' }]);
+
+        const stream = provider.chatStream({ model, messages: promptMessages, temperature: 0.3 });
+        let accumulated = '';
+
+        for await (const chunk of stream) {
+          if (chunk.content) {
+            accumulated += chunk.content;
+            setMessages(prev => prev.map(m =>
+              m.id === assistantId ? { ...m, content: accumulated, citations: results } : m
+            ));
+          }
+        }
+      } else {
+        const assistantId = `assistant-${Date.now()}`;
+        setMessages(prev => [...prev, {
+          id: assistantId,
+          role: 'assistant',
+          content: buildResponse(currentInput, results),
+          citations: results
+        }]);
+      }
     } catch (err) {
-      logger.error('Ask retrieval failed', err);
+      logger.error('Chat failed', err);
       const errorId = `error-${Date.now()}`;
-      setMessages(prev => [...prev, { id: errorId, role: 'assistant', content: 'Sorry, I encountered an issue while searching your local library.' }]);
+      setMessages(prev => [...prev, { id: errorId, role: 'assistant', content: 'Sorry, I encountered an issue while processing your request.' }]);
     } finally {
       setIsSearching(false);
     }
-  }
+  }, [input, llmAvailable, isSearching]);
 
   return (
     <div className="chat-view">
       <div className="ask-header">
         <div className="local-status-chip">
-          <ShieldCheck size={14} />
-          <span>Local search only</span>
+          {llmAvailable ? <Sparkles size={14} /> : <ShieldCheck size={14} />}
+          <span>{llmAvailable ? 'LLM powered' : 'Local search only'}</span>
         </div>
         <div className="offline-badge">Offline ready</div>
       </div>
@@ -165,7 +217,7 @@ function Chat({ onCreateEntity, onNavigate }: ChatProps): React.ReactElement {
           <div className="message assistant loading">
             <div className="searching-indicator">
               <Loader2 size={16} className="animate-spin" />
-              <span>Retrieving local context...</span>
+              <span>{llmAvailable ? 'Thinking...' : 'Retrieving local context...'}</span>
             </div>
           </div>
         )}

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -172,11 +172,62 @@ const Editor: React.FC<EditorProps> = ({ editingEntityId, onEditComplete }) => {
           sourceUrl: sourceUrl.trim() || undefined,
         });
 
+        // Reconcile claims and mentions from editor content
+        const { doc } = editor.state;
+        const claims: { statement: string; source: string; status: string }[] = [];
+        const mentions: { id: string; name: string }[] = [];
+
+        doc.descendants((node) => {
+          const claimMark = node.marks.find(mark => mark.type.name === 'claim');
+          if (claimMark && node.isText && node.text) {
+            claims.push({
+              statement: node.text,
+              source: (claimMark.attrs.source as string) || 'Manual entry',
+              status: (claimMark.attrs.verification_status as string) || 'unverified'
+            });
+          }
+
+          const mentionMark = node.marks.find(mark => mark.type.name === 'mention');
+          if (mentionMark) {
+            mentions.push({
+              id: mentionMark.attrs.entityId as string,
+              name: mentionMark.attrs.entityName as string
+            });
+          }
+          return true;
+        });
+
+        const statements: { sql: string; bind?: (string | number | boolean | null)[] }[] = [];
+
+        // Delete existing claims and links for this entity
+        statements.push({ sql: 'DELETE FROM claims WHERE entity_id = ?', bind: [editingEntityId] });
+        statements.push({ sql: 'DELETE FROM links WHERE source_id = ? AND relation = ?', bind: [editingEntityId, 'mentions'] });
+
+        // Insert reconciled claims
+        for (const claim of claims) {
+          statements.push({
+            sql: 'INSERT INTO claims (entity_id, statement, confidence, evidence, source, verification_status) VALUES (?, ?, ?, ?, ?, ?)',
+            bind: [editingEntityId, claim.statement, 1.0, 'Extracted from editor', claim.source, claim.status]
+          });
+        }
+
+        // Insert reconciled mentions
+        for (const mention of mentions) {
+          statements.push({
+            sql: 'INSERT INTO links (source_id, target_id, relation, metadata) VALUES (?, ?, ?, ?)',
+            bind: [editingEntityId, mention.id, 'mentions', JSON.stringify({ name: mention.name })]
+          });
+        }
+
+        if (statements.length > 0) {
+          await repository.transaction(statements);
+        }
+
         // Update search index
         await upsertToSearchIndex(editingEntityId);
 
-        logger.info('Entity updated', { id: entity.id });
-        setStatus({ type: 'success', message: 'Entity updated successfully!' });
+        logger.info('Entity updated with claim/mention reconciliation', { id: entity.id, claims: claims.length, links: mentions.length });
+        setStatus({ type: 'success', message: `Updated successfully! (${claims.length} claims, ${mentions.length} links)` });
         onEditComplete?.();
       } else {
         // Create new entity

--- a/src/features/graph/GraphControls.tsx
+++ b/src/features/graph/GraphControls.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Focus, Camera, RotateCcw, Loader2, Layout, LayoutDashboard, Download, CircleDot, Sparkles, FolderOpen } from 'lucide-react';
+import { Focus, Camera, RotateCcw, Loader2, Layout, LayoutDashboard, Download, CircleDot, Sparkles, FolderOpen, Undo2, Redo2 } from 'lucide-react';
 import SyncToggle from '../../components/SyncToggle';
 import { extractEntities } from '../../lib/ai/entity-extractor';
 import type { EntityExtractionResult, ExtractedEntity, ExtractedRelationship } from '../../lib/ai/entity-extractor';
@@ -27,6 +27,10 @@ interface GraphControlsProps {
   onSnapshotModeChange?: (active: boolean) => void;
   layout?: 'circular' | 'force' | 'hierarchical';
   onLayoutChange?: (layout: 'circular' | 'force' | 'hierarchical') => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
+  onUndo?: () => void;
+  onRedo?: () => void;
 }
 
 const GraphControls: React.FC<GraphControlsProps> = ({
@@ -43,6 +47,10 @@ const GraphControls: React.FC<GraphControlsProps> = ({
   onSnapshotModeChange,
   layout = 'force',
   onLayoutChange,
+  canUndo = false,
+  canRedo = false,
+  onUndo,
+  onRedo,
 }) => {
   const repository = useRepository();
   const [showSaveModal, setShowSaveModal] = useState(false);
@@ -128,6 +136,26 @@ const GraphControls: React.FC<GraphControlsProps> = ({
       >
         <Focus size={16} /> {focusMode ? 'Show All' : 'Focus Neighborhood'}
       </button>
+      {onUndo && (
+        <button
+          onClick={onUndo}
+          disabled={!canUndo}
+          aria-label="Undo entity deletion"
+          title="Undo (Ctrl+Z)"
+        >
+          <Undo2 size={16} /> Undo
+        </button>
+      )}
+      {onRedo && (
+        <button
+          onClick={onRedo}
+          disabled={!canRedo}
+          aria-label="Redo entity deletion"
+          title="Redo (Ctrl+Shift+Z)"
+        >
+          <Redo2 size={16} /> Redo
+        </button>
+      )}
       {onExportPNG && (
         <button
           onClick={onExportPNG}

--- a/src/features/graph/GraphKeyboardNav.ts
+++ b/src/features/graph/GraphKeyboardNav.ts
@@ -15,7 +15,8 @@ export function useGraphKeyboardNavigation(
   setSelectedNode: (node: string | null) => void,
   focusRingIndex: number,
   setFocusRingIndex: (index: number) => void,
-  repository: IRepository
+  repository: IRepository,
+  beforeDelete?: (entityId: string) => void
 ) {
   useEffect(() => {
     if (!container) return;
@@ -131,6 +132,7 @@ export function useGraphKeyboardNavigation(
         case 'Delete':
         case 'Backspace': {
           if (selectedNode && window.confirm(`Delete "${entities.find(e => e.id === selectedNode)?.name}"? This will also delete all claims and links for this entity.`)) {
+            beforeDelete?.(selectedNode);
             void repository.deleteEntity(selectedNode).then(() => {
               void removeFromSearchIndex(selectedNode);
               logger.info('Entity deleted via keyboard', { id: selectedNode });
@@ -144,5 +146,5 @@ export function useGraphKeyboardNavigation(
 
     container.addEventListener('keydown', handleKeyDown);
     return () => { container.removeEventListener('keydown', handleKeyDown); };
-  }, [container, sigmaInstance, graph, entities, selectedNode, setSelectedNode, focusRingIndex, setFocusRingIndex, repository]);
+  }, [container, sigmaInstance, graph, entities, selectedNode, setSelectedNode, focusRingIndex, setFocusRingIndex, repository, beforeDelete]);
 }

--- a/src/features/graph/GraphView.tsx
+++ b/src/features/graph/GraphView.tsx
@@ -16,6 +16,7 @@ import { useGraphTouchGestures } from './GraphTouchHandler';
 import { useGraphSnapshotManager } from './GraphSnapshotManager';
 import { useGraphSyncEvents } from './GraphSyncEvents';
 import { getGraphThemeTokens, onThemeChange } from '../../lib/theme-tokens';
+import { useGraphUndoRedo } from './useGraphUndoRedo';
 
 type LayoutType = 'circular' | 'force' | 'hierarchical';
 
@@ -41,6 +42,7 @@ const GraphView: React.FC<Props> = ({
   onEditEntity,
 }) => {
   const repository = useRepository();
+  const { canUndo, canRedo, pushDelete, undo, redo } = useGraphUndoRedo(repository);
   const containerRef = useRef<HTMLDivElement>(null);
   const sigmaInstance = useRef<Sigma | null>(null);
   const graphRef = useRef<Graph>(new Graph());
@@ -88,7 +90,8 @@ const GraphView: React.FC<Props> = ({
     setSelectedNode,
     focusRingIndex,
     setFocusRingIndex,
-    repository
+    repository,
+    (id: string) => { void pushDelete(id); }
   );
 
   useGraphTouchGestures(
@@ -444,6 +447,10 @@ const GraphView: React.FC<Props> = ({
             onSnapshotModeChange={(active) => { if (!active) handleExitSnapshot(); }}
             layout={layout}
             onLayoutChange={setLayout}
+            canUndo={canUndo}
+            canRedo={canRedo}
+            onUndo={() => void undo()}
+            onRedo={() => void redo()}
           />
         </div>
       )}

--- a/src/features/graph/useGraphUndoRedo.ts
+++ b/src/features/graph/useGraphUndoRedo.ts
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useState } from 'react';
+import type { IRepository } from '../../db/repository';
+import type { Entity } from '../../lib/validation';
+import { logger } from '../../lib/logger';
+
+interface UndoEntry {
+  entity: Entity;
+  claims: { statement: string; source: string; verification_status: string }[];
+  links: { source_id: string; target_id: string; relation: string; metadata?: string }[];
+}
+
+const MAX_HISTORY = 50;
+
+export function useGraphUndoRedo(repository: IRepository) {
+  const undoStack = useRef<UndoEntry[]>([]);
+  const redoStack = useRef<UndoEntry[]>([]);
+  const [undoCount, setUndoCount] = useState(0);
+  const [redoCount, setRedoCount] = useState(0);
+
+  const pushDelete = useCallback(async (entityId: string) => {
+    try {
+      const entity = await repository.getEntityById(entityId);
+      if (!entity) return;
+
+      const claims = await repository.getClaimsByEntityId(entityId);
+      const claimData = claims.map(c => ({
+        statement: c.statement,
+        source: c.source || 'Manual entry',
+        verification_status: c.verification_status,
+      }));
+
+      const allLinks = await repository.getAllLinks();
+      const linkData = allLinks
+        .filter(l => l.source_id === entityId || l.target_id === entityId)
+        .map(l => ({
+          source_id: l.source_id,
+          target_id: l.target_id,
+          relation: l.relation,
+          metadata: l.metadata ? JSON.stringify(l.metadata) : undefined,
+        }));
+
+      undoStack.current.push({ entity, claims: claimData, links: linkData });
+      if (undoStack.current.length > MAX_HISTORY) undoStack.current.shift();
+      redoStack.current = [];
+      setUndoCount(undoStack.current.length);
+      setRedoCount(0);
+    } catch (err) {
+      logger.error('Failed to capture undo state', err);
+    }
+  }, [repository]);
+
+  const undo = useCallback(async (): Promise<boolean> => {
+    const entry = undoStack.current.pop();
+    if (!entry) return false;
+
+    try {
+      const { entity, claims, links } = entry;
+      const statements: { sql: string; bind?: (string | number | boolean | null)[] }[] = [];
+
+      statements.push({
+        sql: 'INSERT INTO entities (id, name, type, description, source_url, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        bind: [entity.id, entity.name, entity.type, entity.description || '', entity.sourceUrl || null, JSON.stringify(entity.metadata || {}), entity.created_at || new Date().toISOString(), entity.updated_at || new Date().toISOString()]
+      });
+
+      for (const claim of claims) {
+        statements.push({
+          sql: 'INSERT INTO claims (entity_id, statement, confidence, evidence, source, verification_status) VALUES (?, ?, ?, ?, ?, ?)',
+          bind: [entity.id, claim.statement, 1.0, 'Restored from undo', claim.source, claim.verification_status]
+        });
+      }
+
+      for (const link of links) {
+        statements.push({
+          sql: 'INSERT INTO links (source_id, target_id, relation, metadata) VALUES (?, ?, ?, ?)',
+          bind: [link.source_id, link.target_id, link.relation, link.metadata || null]
+        });
+      }
+
+      await repository.transaction(statements);
+      redoStack.current.push(entry);
+      setUndoCount(undoStack.current.length);
+      setRedoCount(redoStack.current.length);
+      logger.info('Undone entity deletion', { entityId: entity.id });
+      return true;
+    } catch (err) {
+      logger.error('Undo failed', err);
+      undoStack.current.push(entry);
+      setUndoCount(undoStack.current.length);
+      return false;
+    }
+  }, [repository]);
+
+  const redo = useCallback(async (): Promise<boolean> => {
+    const entry = redoStack.current.pop();
+    if (!entry) return false;
+
+    try {
+      await repository.deleteEntity(entry.entity.id);
+      undoStack.current.push(entry);
+      setUndoCount(undoStack.current.length);
+      setRedoCount(redoStack.current.length);
+      logger.info('Redone entity deletion', { entityId: entry.entity.id });
+      return true;
+    } catch (err) {
+      logger.error('Redo failed', err);
+      redoStack.current.push(entry);
+      setRedoCount(redoStack.current.length);
+      return false;
+    }
+  }, [repository]);
+
+  return {
+    canUndo: undoCount > 0,
+    canRedo: redoCount > 0,
+    undoCount,
+    redoCount,
+    pushDelete,
+    undo,
+    redo,
+  };
+}

--- a/src/features/mindmap/MindMapView.tsx
+++ b/src/features/mindmap/MindMapView.tsx
@@ -9,14 +9,13 @@ import { logger } from '../../lib/logger';
 import { upsertToSearchIndex } from '../../lib/search';
 import { perf } from '../../lib/perf';
 import SyncToggle from '../../components/SyncToggle';
-import { ChevronDown, Layers, Filter, Info, ChevronRight, Plus, GitBranch, Pencil, Trash2, Image } from 'lucide-react';
+import { ChevronDown, Layers, Filter, Info, ChevronRight, Plus, GitBranch, Pencil, Trash2, Image, Undo2, Redo2 } from 'lucide-react';
 
 const COLLAPSED_BY_DEFAULT_THRESHOLD = 20;
 const EXPENSIVE_RECALC_THRESHOLD = 50;
 
 interface Props {
   rootEntity: Entity;
-  relatedEntities: Entity[];
   entities: Entity[];
   links: Link[];
   onEntityClick?: (entityId: string) => void;
@@ -68,7 +67,6 @@ function addAriaAttributesToContainer(container: HTMLElement): void {
 
 const MindMapView: React.FC<Props> = ({
   rootEntity: propsRootEntity,
-  relatedEntities: _relatedEntities,
   entities,
   links,
   onEntityClick
@@ -412,6 +410,24 @@ const MindMapView: React.FC<Props> = ({
           aria-label="Delete selected node"
         >
           <Trash2 size={14} /> Delete
+        </button>
+        <button
+          onClick={() => mindInstance.current?.undo()}
+          className="filter-chip"
+          disabled={!isMindReady}
+          title="Undo (Ctrl+Z)"
+          aria-label="Undo last action"
+        >
+          <Undo2 size={14} /> Undo
+        </button>
+        <button
+          onClick={() => mindInstance.current?.redo()}
+          className="filter-chip"
+          disabled={!isMindReady}
+          title="Redo (Ctrl+Shift+Z)"
+          aria-label="Redo last action"
+        >
+          <Redo2 size={14} /> Redo
         </button>
 
         <span style={{ width: '1px', height: '20px', background: 'var(--border-default)', margin: '0 4px' }} />

--- a/src/features/mindmap/__tests__/MindMapView.test.tsx
+++ b/src/features/mindmap/__tests__/MindMapView.test.tsx
@@ -122,8 +122,7 @@ const createEntity = (id: string, name: string): Entity => ({
 });
 
 const baseRoot: Entity = createEntity(VALID_PARENT_UUID, 'Root');
-const baseRelated: Entity[] = [createEntity(VALID_CHILD_UUID, 'Child')];
-const baseEntities: Entity[] = [baseRoot, ...baseRelated];
+const baseEntities: Entity[] = [baseRoot, createEntity(VALID_CHILD_UUID, 'Child')];
 const baseLinks: Link[] = [];
 
 async function flushAsync(): Promise<void> {
@@ -169,7 +168,7 @@ describe('MindMapView', () => {
     const { container } = render(
       <MindMapView
         rootEntity={baseRoot}
-        relatedEntities={baseRelated}
+
         entities={baseEntities}
         links={baseLinks}
       />,
@@ -187,7 +186,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -218,7 +217,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -244,7 +243,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -266,7 +265,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -291,7 +290,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -315,7 +314,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -336,7 +335,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -358,7 +357,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -382,7 +381,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -405,7 +404,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -427,7 +426,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -449,7 +448,7 @@ describe('MindMapView', () => {
       render(
         <MindMapView
           rootEntity={baseRoot}
-          relatedEntities={baseRelated}
+  
           entities={baseEntities}
           links={baseLinks}
         />,
@@ -472,7 +471,7 @@ describe('MindMapView', () => {
     render(
       <MindMapView
         rootEntity={baseRoot}
-        relatedEntities={baseRelated}
+
         entities={baseEntities}
         links={baseLinks}
       />,

--- a/src/features/search/SearchPanel.tsx
+++ b/src/features/search/SearchPanel.tsx
@@ -183,7 +183,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
         };
 
         try {
-          await progressiveSearch(query, onStage, { type: typeFilter, signal: controller.signal });
+          await progressiveSearch(query, onStage, { type: typeFilter, signal: controller.signal, semantic: useSemantic });
         } catch (err) {
           logger.error('Search failed', err);
           setIsSearching(false);

--- a/src/lib/search/progressive.ts
+++ b/src/lib/search/progressive.ts
@@ -382,7 +382,7 @@ export type ProgressiveSearchCallback = (results: RankedResult[], stage: 'exact'
 export const progressiveSearch = async (
   query: string,
   onResults: ProgressiveSearchCallback,
-  options?: { type?: string; limit?: number; signal?: AbortSignal },
+  options?: { type?: string; limit?: number; signal?: AbortSignal; semantic?: boolean },
 ): Promise<void> => {
   if (options?.signal?.aborted) return;
 
@@ -390,7 +390,7 @@ export const progressiveSearch = async (
   if (options?.signal?.aborted) return;
   void onResults(exactResults, 'exact');
 
-  if (embeddingsReady && embeddingsPlugin) {
+  if (options?.semantic !== false && embeddingsReady && embeddingsPlugin) {
     const semanticResults = await semanticSearch(query, { ...options, type: options?.type });
     if (options?.signal?.aborted) return;
     void onResults(semanticResults, 'semantic');

--- a/tests/e2e/entity-crud.spec.ts
+++ b/tests/e2e/entity-crud.spec.ts
@@ -51,7 +51,7 @@ test.describe('Entity CRUD', () => {
     await titleInput.fill(updatedTitle);
     await page.waitForTimeout(500);
     await page.click('button:has-text("Update Entity")');
-    await expect(page.locator('[role="alert"]')).toContainText(/updated successfully|Saved successfully/, { timeout: 10000 });
+    await expect(page.locator('[role="alert"]')).toContainText(/updated successfully|Updated successfully|Saved successfully/i, { timeout: 10000 });
 
     await ensureNavVisible(page);
     await page.locator('.nav-button').filter({ hasText: 'Library', visible: true }).first().click();


### PR DESCRIPTION
## Summary
- **M13**: Remove vestigial `_relatedEntities` prop from MindMapView and App.tsx
- **M8/4.3**: Fix semantic toggle to actually control `progressiveSearch` pipeline
- **M9**: Wire claim/mention reconciliation into entity update path (delete+reinsert via transaction)
- **M11/33.7**: Add graph undo/redo via `useGraphUndoRedo` hook; wire MindElixir built-in undo/redo
- **33.5/4.1**: Wire Chat.tsx to LLM providers with streaming, context injection, and search-only fallback

## Changes
- `src/features/graph/useGraphUndoRedo.ts` (new) — undo/redo hook for graph entity deletion
- `src/features/graph/GraphControls.tsx` — undo/redo buttons
- `src/features/graph/GraphKeyboardNav.ts` — capture state before delete
- `src/features/graph/GraphView.tsx` — wire undo/redo hook
- `src/features/mindmap/MindMapView.tsx` — undo/redo buttons via MindElixir API
- `src/features/chat/Chat.tsx` — LLM provider integration with streaming
- `src/features/editor/Editor.tsx` — claim/mention reconciliation on update
- `src/features/search/SearchPanel.tsx` — pass semantic flag to search
- `src/lib/search/progressive.ts` — add semantic option to progressiveSearch

## Verification
- `pnpm run lint` ✅
- `pnpm run typecheck` ✅
- `pnpm run test` — 662 tests passing ✅
- `pnpm run build` ✅