### PR TITLE
ci(deepsource): disable Qwik-specific rules

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -20,6 +20,11 @@ enabled = true
   [analyzers.meta]
   max_complexity = "30"
   max_functions = "50"
+  skip_doc_coverage = ["test"]
 
   [analyzers.meta.ratings]
     documentation_coverage = "A"
+
+  [analyzers.meta.checks]
+  # Disable Qwik-specific rules (project doesn't use Qwik)
+  Biome_lint_correctness_useQwikValidLexicalScope = "off"


### PR DESCRIPTION
Disables Biome's `useQwikValidLexicalScope` rule in DeepSource config.

This project uses React, not Qwik framework. The rule was incorrectly flagging normal TypeScript arrow functions as "non-serializable expressions" that need `` wrapping (a Qwik-specific serialization pattern).

Fixes false positives on PRs #356, #368 and future PRs.