### PR TITLE
Enforce noopener noreferrer on target="_blank" links

### DIFF
--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -43,6 +43,17 @@ describe('sanitizeHtml', () => {
     const result = sanitizeHtml('<style>body{color:red}</style>');
     expect(result).not.toContain('<style>');
   });
+
+  it('enforces noopener noreferrer on target="_blank" links', () => {
+    const result = sanitizeHtml('<a href="https://google.com" target="_blank">click</a>');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it('strips dangerous rel values when target="_blank" is present', () => {
+    const result = sanitizeHtml('<a href="https://google.com" target="_blank" rel="opener">click</a>');
+    expect(result).toContain('rel="noopener noreferrer"');
+    expect(result).not.toMatch(/\srel="opener"/);
+  });
 });
 
 describe('stripHtmlTags', () => {

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1,5 +1,16 @@
 import DOMPurify from 'dompurify';
 
+/**
+ * Add hook to enforce noopener noreferrer on target="_blank" links.
+ * This prevents tabnabbing attacks where a malicious site can control
+ * the opening page via window.opener.
+ */
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 export function sanitizeHtml(html: string): string {
   return DOMPurify.sanitize(html, {
     ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'ul', 'ol', 'li', 'p', 'br', 'span', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'code', 'pre', 'del'],


### PR DESCRIPTION
This change improves the security posture of the application by preventing tabnabbing attacks. It uses a DOMPurify hook in the `sanitizeHtml` utility to ensure that all links intended to open in a new tab (`target="_blank"`) are automatically assigned the `rel="noopener noreferrer"` attribute. This is a critical security best practice to prevent the opened page from accessing and potentially manipulating the original page via `window.opener`.

The implementation is robust as it:
1. Automatically adds the required `rel` attributes.
2. Ensures that any existing dangerous `rel` values (like `opener`) are replaced.
3. Is applied globally via the central `sanitizeHtml` function used throughout the app for rendering user-provided or AI-generated content.

New unit tests in `src/lib/__tests__/security.test.ts` confirm the enforcement logic.

---
*PR created automatically by Jules for task [8704005040140543634](https://jules.google.com/task/8704005040140543634) started by @d-oit*