### PR TITLE
security: harden supply-chain posture

### DIFF
--- a/.github/workflows/version-propagation.yml
+++ b/.github/workflows/version-propagation.yml
@@ -44,3 +44,52 @@ jobs:
             git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
               HEAD:${{ github.ref }}
           fi
+
+  generate-sbom:
+    # Generate a CycloneDX SBOM for supply-chain transparency on every release.
+    # Runs only on main to avoid creating SBOM artefacts for feature branches.
+    if: github.ref == 'refs/heads/main'
+    needs: propagate-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write  # required to upload release assets if desired
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          # pnpm 11 is required for the built-in `pnpm sbom` command.
+          # This does not change the project's packageManager field; it is
+          # scoped to this workflow job only.
+          version: '11'
+
+      - name: Install dependencies (lockfile only, no scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Read version
+        id: version
+        run: echo "version=$(cat VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          pnpm sbom \
+            --sbom-format cyclonedx \
+            --sbom-type application \
+            --out sbom.cdx.json
+
+      - name: Upload SBOM as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sbom-${{ steps.version.outputs.version }}
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,23 +1,32 @@
 # Trivy ignore file — one rule per line.
 # Acceptable formats: <trivy-id>, <cve-id>, <ghsa-id>, or regex pattern.
 #
-# All entries below are dompurify 3.4.6 CVEs that we cannot upgrade past
-# because dompurify >=3.4.7 is incompatible with happy-dom in our test
-# environment (throws "Failed to execute 'insertBefore' on 'Node'" in
-# the security unit tests). Upgrading dompurify requires migrating the
-# test env to jsdom — tracked in plans/041-post-export-cleanup.
+# All entries below are dompurify CVEs (all fixed in ≥3.4.7).
+# The pnpm overrides section in package.json pins dompurify@3.4.11 globally,
+# which fully patches each CVE listed here. These ignores suppress residual
+# Trivy reports triggered by transitive-dep lockfile entries that still
+# reference older dompurify versions before the override resolves them.
+#
+# Review cadence: re-evaluate whenever the dompurify override is bumped or
+# removed, or when a new dompurify CVE is published.
 
-# Hook mutation of data.allowedTags (IN_PLACE mode not used in this app)
+# Hook mutation of data.allowedTags / data.allowedAttributes permanently
+# pollutes DEFAULT_ALLOWED_TAGS / DEFAULT_ALLOWED_ATTR (IN_PLACE mode not used
+# in this app). Fixed in dompurify 3.4.6.
 GHSA-76mc-f452-cxcm
 
-# IN_PLACE Sanitization Bypass via Shadow Root (IN_PLACE mode not used)
+# IN_PLACE Sanitization Bypass via Shadow Root inside <template>.content
+# (IN_PLACE mode not used in this app). Fixed in dompurify 3.4.7.
 GHSA-rp9w-3fw7-7cwq
 
-# Trusted Types policy poisoning (we do not use Trusted Types)
+# Trusted Types policy poisoning (we do not use Trusted Types).
+# Fixed in dompurify 3.4.7.
 GHSA-vxr8-fq34-vjx9
 
-# SAFE_FOR_TEMPLATES bypass (we do not use SAFE_FOR_TEMPLATES)
+# SAFE_FOR_TEMPLATES bypass (we do not use SAFE_FOR_TEMPLATES).
+# Fixed in dompurify 3.4.7.
 GHSA-gvmj-g25r-r7wr
 
-# Hook mutation of data.allowedTags (IN_PLACE mode not used)
+# IN_PLACE Sanitization Bypass via Attached Shadow Root inside <template>.content
+# (IN_PLACE mode not used in this app). Fixed in dompurify 3.4.7.
 CVE-2026-49978

--- a/NOTICE
+++ b/NOTICE
@@ -8,6 +8,27 @@ documentation would be appreciated but is not required.
 
 ================================================================================
 
+DEPENDENCY OVERRIDES
+
+The following pnpm overrides are applied in package.json to address known
+security vulnerabilities in transitive dependencies:
+
+dompurify@3.4.11
+  Package: dompurify (https://github.com/cure53/DOMPurify)
+  Override reason: Multiple transitive dependencies pull in dompurify at
+    versions prior to 3.4.7, which are affected by the following CVEs:
+      - GHSA-76mc-f452-cxcm: Hook mutation permanently pollutes DEFAULT_ALLOWED_TAGS
+      - GHSA-rp9w-3fw7-7cwq / CVE-2026-49978: IN_PLACE bypass via shadow root
+      - GHSA-vxr8-fq34-vjx9: Trusted Types policy poisoning
+      - GHSA-gvmj-g25r-r7wr: SAFE_FOR_TEMPLATES bypass
+  All four are patched in dompurify ≥3.4.7. The override pins 3.4.11
+  (current latest at time of writing) globally across the dependency tree.
+  The application itself does not use IN_PLACE mode, Trusted Types, or
+  SAFE_FOR_TEMPLATES, but the override is retained for defence-in-depth and
+  to suppress Trivy findings on transitive lockfile entries.
+
+================================================================================
+
 THIRD-PARTY COMPONENTS
 
 This software includes or references the following third-party components:


### PR DESCRIPTION
## Summary

Addresses three supply-chain security recommendations:

### 1. Fix stale `.trivyignore` header comment
The previous header said CVE ignores existed due to a happy-dom test-env incompatibility blocking upgrade past dompurify 3.4.6. That rationale was stale — the `pnpm overrides` in `package.json` already pins `dompurify@3.4.11` globally. Updated the comment to accurately reflect why the ignores are still needed: Trivy still flags transitive lockfile entries at older dompurify versions even after the override resolves them. Also fixed a truncated CVE-2026-49978 entry (missing description) and added a review cadence note.

### 2. Document the `dompurify@3.4.11` pnpm override in NOTICE
Added a `DEPENDENCY OVERRIDES` section to `NOTICE` documenting why the override exists, which CVEs it addresses, and confirmation that all are patched in dompurify ≥3.4.7. Per-CVE rationale included:
- `GHSA-76mc-f452-cxcm` — hook mutation pollutes DEFAULT_ALLOWED_TAGS (fixed 3.4.6)
- `GHSA-rp9w-3fw7-7cwq` / `CVE-2026-49978` — IN_PLACE bypass via shadow root (fixed 3.4.7)
- `GHSA-vxr8-fq34-vjx9` — Trusted Types policy poisoning (fixed 3.4.7)
- `GHSA-gvmj-g25r-r7wr` — SAFE_FOR_TEMPLATES bypass (fixed 3.4.7)

### 3. Add CycloneDX SBOM generation to the release workflow
Added a `generate-sbom` job to `version-propagation.yml` that:
- Runs only on `main` (gated with `if: github.ref == 'refs/heads/main'`)
- Depends on `propagate-version` so the version is stamped before the SBOM
- Installs pnpm 11 (scoped to the job only — project `packageManager` stays at 10.30.3) to use the native `pnpm sbom` command
- Generates `sbom.cdx.json` (CycloneDX 1.7, application type)
- Uploads as a workflow artifact named `sbom-<version>` with 90-day retention
- Uses the same pinned action SHAs as the rest of the repo

## Testing
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (853 tests passing)
- `pnpm build` ✅

No code changes — all modifications are documentation, config comments, and CI workflow.