### PR TITLE
feat(skill): add static-analysis-suppression skill

### DIFF
--- a/.agents/skills/static-analysis-suppression/SKILL.md
+++ b/.agents/skills/static-analysis-suppression/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: static-analysis-suppression
+description: >-
+  Suppress false positive or pre-existing issues from static analysis tools on PRs.
+  Use when Codacy, DeepSource, or ESLint blocks a PR with inline review comments
+  that are false positives, pre-existing (not introduced by the diff), or
+  config-level noise (e.g., Qwik-specific Biome rules in a React project).
+  Covers all suppression methods: code-level fixes, eslint-disable comments,
+  config changes (.codacy.yml, .deepsource.toml), and admin merge override.
+version: "1.0"
+template_version: "1.0"
+metadata:
+  source: codified from ~12 sessions of PR CI fix work
+  related-skills: codacy, git-github-workflow
+allowed-tools: "read grep bash edit write"
+---
+
+# Static Analysis Suppression on PRs
+
+Systematic workflow for clearing Codacy, DeepSource, and ESLint blockers
+on pull requests. **Fix code before suppressing config.**
+
+## Decision Tree
+
+```
+PR blocked by static analysis check?
+├── ✓ Code-level fix is simplest/cleanest → fix source code
+├── ✓ False positive from external tool?
+│   ├── DeepSource: use code rewrite (const → arrow, etc.)
+│   ├── Codacy ESLint: use `// eslint-disable-next-line <rule>` inline
+│   ├── Codacy Biome/Qwik: check .codacy.yml `engines.biome.config` rules
+│   └── Pre-existing complexity: .deepsource.toml analyzer.meta.checks
+├── ✗ Config-only fix (no code change)?
+│   ├── Codacy: .codacy.yml `engines.eslint-8.disable_rules` or `exclude_paths`
+│   └── DeepSource: .deepsource.toml `[analyzers.meta.checks]`
+└── ✗ All real checks pass, only policy tool blocks?
+    → `gh pr merge --admin` override
+```
+
+## Workflow
+
+### 1. Diagnose the blocker
+
+Check which tool is blocking and why:
+
+```bash
+gh pr checks <PR#>  # list all status checks
+gh pr view <PR#> --json statusCheckRollup  # full detail incl. DeepSource/Codacy
+```
+
+Classify the issue:
+
+| Category | Example | Fix method |
+|----------|---------|------------|
+| Genuine lint error | unused variable, missing type | Fix source code |
+| DeepSource code pattern | `function` decl → `const` arrow | Code rewrite |
+| DeepSource redundant | `mockResolvedValue(undefined)` | Remove `undefined` arg |
+| Codacy ESLint8_* | `security/detect-object-injection` | `disable_rules` in `.codacy.yml` |
+| Codacy Biome (Qwik) | `useQwikValidLexicalScope` | `biome.json` or `.deepsource.toml` |
+| Pre-existing complexity | `max-complexity "30"` | `.deepsource.toml` `[analyzers.meta]` |
+| ESLint disable needed | `react-hooks/refs`, `set-state-in-effect` | `// eslint-disable-next-line` inline |
+
+### 2. Apply suppression
+
+#### Code rewrite (preferred)
+
+DeepSource JS-0067: `export default async function foo() {}`
+→ `const foo = (): void => { ... }; export default foo;`
+
+DeepSource JS-0240: `{ type: type }`
+→ `{ type }`
+
+DeepSource JS-W1042: `vi.fn().mockResolvedValue(undefined)`
+→ `vi.fn().mockResolvedValue()`
+
+DeepSource JS-0098: `void someFunction()`
+→ `someFunction()`
+
+#### eslint-disable inline
+
+```ts
+// eslint-disable-next-line react-hooks/refs -- hook uses refs inside effects, not for rendering
+```
+
+For multiple consecutive lines, use block form:
+
+```ts
+/* eslint-disable react-hooks/rules-of-hooks */
+useHook(condition);
+useHook(other);
+/* eslint-enable react-hooks/rules-of-hooks */
+```
+
+#### Codacy config (.codacy.yml)
+
+```yaml
+engines:
+  eslint-8:
+    disable_rules:
+      - "ESLint8_security_detect-object-injection"
+```
+
+Codacy YAML requires `---` preamble on line 1.
+
+#### DeepSource config (.deepsource.toml)
+
+```toml
+[analyzers.meta.checks]
+Biome_lint_correctness_useQwikValidLexicalScope = "off"
+```
+
+### 3. Admin merge (last resort)
+
+When ALL real functional checks pass but a static analysis tool
+still blocks (pre-existing issue, known false positive):
+
+```bash
+gh pr merge <PR#> --squash --admin --subject "<message>"
+```
+
+## Common DeepSource Issue Codes
+
+| Code | Issue | Fix |
+|------|-------|-----|
+| JS-0067 | `function` decl in module scope | Arrow `const` assignment + export |
+| JS-0240 | `type: type` redundant key | Property shorthand |
+| JS-0339 | `!` non-null assertion | Proper type narrowing or optional chaining |
+| JS-0357 | Arrow `const` used before decl | Move definition above callers |
+| JS-0098 | `void` expression | Remove `void` keyword |
+| JS-W1042 | `mockResolvedValue(undefined)` | Omit `undefined` argument |
+| JS-C1003 | `import * as` namespace | Named imports for actually-used exports |
+| R1005 | Complexity exceeds threshold | `.deepsource.toml` `max_complexity` or code split |
+
+## Common Codacy ESLint Issue Codes
+
+| Code | Issue | Fix |
+|------|-------|-----|
+| `security/detect-object-injection` | `obj[key]` access | Not in local ESLint — `disable_rules` only |
+| `no-confusing-void-expression` | Arrow returning void | `{ fn(); }` braces |
+| `useImportType` | Value import for type-only | Split `import { foo, type Bar }` |
+| `react-hooks/refs` | Ref not in dependency array | `// eslint-disable-next-line` |
+| `react-hooks/set-state-in-effect` | setState inside effect | `// eslint-disable-next-line` |

--- a/.agents/skills/static-analysis-suppression/evals/evals.json
+++ b/.agents/skills/static-analysis-suppression/evals/evals.json
@@ -1,0 +1,189 @@
+{
+  "skill_name": "static-analysis-suppression",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "fix this pr https://github.com/example/repo/pull/42 - deepsource js-0067 is blocking merge",
+      "expected_output": "Identifies JS-0067 as 'function declaration in module scope'. Convert to const arrow + export default. Step: diagnose DeepSource check, find flagged line, rewrite to const, push.",
+      "files": [],
+      "assertions": [
+        "Identifies JS-0067 as 'function declaration in module scope'",
+        "Recommends const arrow + export default rewrite",
+        "Mentions the decision tree: fix code before suppressing config"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Codacy is blocking PR #50 with security/detect-object-injection but we don't have that rule in our local ESLint",
+      "expected_output": "Diagnoses that security/detect-object-injection is Codacy-only. Cannot eslint-disable. Must add to .codacy.yml engines.eslint-8.disable_rules or restructure code.",
+      "files": [],
+      "assertions": [
+        "Identifies security/detect-object-injection is not in local ESLint",
+        "Recommends .codacy.yml disable_rules as the fix",
+        "Notes that eslint-disable won't work for Codacy-only rules"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "can you suppress this mockResolvedValue(undefined) deepsource warning",
+      "expected_output": "Identifies JS-W1042. Fix: remove undefined argument — mockResolvedValue() returns undefined by default. Simple code change.",
+      "files": [],
+      "assertions": [
+        "Identifies JS-W1042",
+        "Recommends removing the undefined argument",
+        "Assesses it as a trivial code-level fix"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "PR #63 has a pre-existing complexity issue flagged by deepsource that I didn't introduce. How do I suppress it?",
+      "expected_output": "Diagnoses as pre-existing complexity (R1005). Recommend .deepsource.toml meta config: max_complexity increase or specific check suppression. Or admin merge if all real checks pass.",
+      "files": [".deepsource.toml"],
+      "assertions": [
+        "Identifies as pre-existing complexity (R1005)",
+        "Recommends .deepsource.toml meta config for suppression",
+        "Offers admin merge as last resort"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Codacy is flagging Qwik-specific rule useQwikValidLexicalScope on our React project - we don't use Qwik",
+      "expected_output": "Identifies as known false positive for React projects. Recommend .deepsource.toml or .codacy.yml suppression for the Biome rule. As a fallback, admin merge.",
+      "files": [".deepsource.toml", ".codacy.yml"],
+      "assertions": [
+        "Identifies as known Qwik false positive",
+        "Recommends config-level suppression",
+        "Notes admin merge as last resort"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "I need to suppress react-hooks/refs eslint errors in my test file - the refs are only used inside effects",
+      "expected_output": "Recommend inline eslint-disable-next-line with comment explaining why. The rule is correct in general but the pattern is safe because refs aren't used during rendering.",
+      "files": [],
+      "assertions": [
+        "Recommends inline eslint-disable-next-line",
+        "Recommends including a comment explaining why"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Codacy flagged 'import type' issue - I have import { Foo, Bar } from './types' where Bar is only used as a type",
+      "expected_output": "Recommend splitting into separate value and type imports, or inline type annotation: import { Foo, type Bar } from './types'.",
+      "files": [],
+      "assertions": [
+        "Recommends splitting into separate value and type imports",
+        "Notes inline type annotation as alternative"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "ESLint flags no-confusing-void-expression on my catch handler: .catch(err => fn(err))",
+      "expected_output": "Add braces around the arrow function body: .catch(err => { fn(err); }). This satisfies ESLint while keeping the same behavior.",
+      "files": [],
+      "assertions": [
+        "Recommends adding braces around arrow body",
+        "Notes this is a Codacy ESLint rule not in local ESLint"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "deepsource is complaining about import * as X - I import a whole module but only use one property",
+      "expected_output": "JS-C1003. Fix: replace import * with named import for only the properties actually used. Example: import { usedFn } from './module' instead of import * as mod.",
+      "files": [],
+      "assertions": [
+        "Identifies JS-C1003",
+        "Recommends named imports for actually-used exports"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "All my real checks pass (lint, test, build) but DeepSource JavaScript check is still failing and blocking the merge",
+      "expected_output": "Diagnose what DeepSource is flagging first (check the run URL). If it's a known false positive or pre-existing issue, and all functional checks pass, use admin merge: gh pr merge <PR#> --squash --admin.",
+      "files": [],
+      "assertions": [
+        "Recommends diagnosing the specific DeepSource issue first",
+        "Offers admin merge override if all real checks pass"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "refactor this api endpoint to use async/await instead of promise chains",
+      "expected_output": "No static analysis suppression needed. This is a pure refactoring task, not a CI suppression issue.",
+      "files": [],
+      "assertions": [
+        "Determines this is not a static analysis suppression task"
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "add a new feature to the user profile page",
+      "expected_output": "No static analysis suppression needed. This is a feature request, not related to CI suppression.",
+      "files": [],
+      "assertions": [
+        "Determines this is not a static analysis suppression task"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "update the README with installation instructions",
+      "expected_output": "No static analysis suppression needed. This is a documentation task.",
+      "files": [],
+      "assertions": [
+        "Determines this is not a static analysis suppression task"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "deepsource flagged JS-0357 - arrow function used before declaration. What do I do?",
+      "expected_output": "Move the helper function definition above the code that calls it. JS-0357 is about hoisting: const arrow functions aren't hoisted like function declarations.",
+      "files": [],
+      "assertions": [
+        "Identifies JS-0357 as hoisting issue",
+        "Recommends moving definition above callers"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "deepsource flagged JS-0240 - type: type. Weird, we're using property shorthand elsewhere",
+      "expected_output": "{ type: type } should be { type }. JS-0240 flags redundant key-value pairs where key and value are the same identifier — use object property shorthand syntax instead.",
+      "files": [],
+      "assertions": [
+        "Identifies JS-0240 as property shorthand",
+        "Recommends using object property shorthand"
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "deepsource flagged JS-0339 - non-null assertion. But I know this value is never null!",
+      "expected_output": "DeepSource JS-0339 is Major severity and requires proper typing. Use optional chaining (?.) instead of non-null assertion (!), or add proper null checks. If the type definition is wrong, fix the type.",
+      "files": [],
+      "assertions": [
+        "Notes JS-0339 is Major severity",
+        "Recommends proper typing over suppression",
+        "Suggests optional chaining as alternative"
+      ]
+    },
+    {
+      "id": 17,
+      "prompt": "fix the lint errors in the CI",
+      "expected_output": "First classify which tool is failing and what type of issues. Run pnpm run lint locally to reproduce. Apply code-level fixes for genuine errors. For false positives, use appropriate suppression method from the decision tree.",
+      "files": [],
+      "assertions": [
+        "Recommends first classifying the failing tool",
+        "Recommends local reproduction",
+        "Follows decision tree for suppression method"
+      ]
+    },
+    {
+      "id": 18,
+      "prompt": "Codacy is failing but all tests pass - how do I bypass it?",
+      "expected_output": "First check what Codacy is flagging via the details URL. If it's a known false positive or pre-existing config issue (e.g., Qwik rules in React project), try config-level fix first. Only if all else fails, use admin merge: gh pr merge --admin.",
+      "files": [],
+      "assertions": [
+        "Recommends diagnosing the specific Codacy issue first",
+        "Notes admin merge as last resort"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/static-analysis-suppression/references/evaluating-skills.md
+++ b/.agents/skills/static-analysis-suppression/references/evaluating-skills.md
@@ -1,0 +1,58 @@
+# Evaluating static-analysis-suppression Skill
+
+## Test Case Design
+
+Design eval prompts that match real PR CI failure scenarios.
+
+Good prompts include:
+- A specific tool name (Codacy, DeepSource, ESLint)
+- An issue code (JS-0067, R1005, ESLint8_security_detect-object-injection)
+- A PR context (blocking merge, failing check)
+
+### should-trigger queries (10)
+
+Vary along these axes:
+- Tool: Codacy / DeepSource / ESLint
+- Severity: false positive / pre-existing / genuine issue
+- Fix method: code rewrite / inline disable / config / admin
+- Explicitness: named rule code / generic "it's blocking"
+
+### should-not-trigger queries (4)
+
+Near-misses that share keywords but need something different:
+- "fix this lint error" where the error is a genuine code bug (should use standard fix, not suppression)
+- Feature requests, documentation tasks, pure refactoring
+
+## Evaluation Procedure
+
+1. **Without skill**: Run should-trigger prompts with no skill loaded.
+   - Expected: generic response, no decision tree, no specific rule codes.
+2. **With skill**: Load static-analysis-suppression, run same prompts.
+   - Expected: follows decision tree, maps to specific rule code, picks correct suppression method, mentions code-before-config order.
+3. **Compare pass rates**: Skill should significantly improve on should-trigger sets without false-triggering on should-not-trigger sets.
+
+## Assertion Patterns
+
+Good assertions for this skill:
+- `"Identifies <rule-code> as <category>"`
+- `"Recommends <fix-method>"`
+- `"Mentions <alternative> as fallback"`
+- `"Determines this is not a static analysis suppression task"` (should-not-trigger)
+
+## Artifact Layout
+
+```
+static-analysis-suppression-workspace/
+└── iteration-1/
+    ├── eval-PR-42-deepsource-js-0067/
+    │   ├── with_skill/
+    │   │   ├── outputs/
+    │   │   ├── timing.json
+    │   │   └── grading.json
+    │   └── without_skill/
+    │       ├── outputs/
+    │       ├── timing.json
+    │       └── grading.json
+    ├── benchmark.json
+    └── feedback.json
+```

--- a/.agents/skills/static-analysis-suppression/references/suppression-methods.md
+++ b/.agents/skills/static-analysis-suppression/references/suppression-methods.md
@@ -1,0 +1,83 @@
+# Suppression Methods Reference
+
+## Code Rewrite (DeepSource)
+
+| Before | After | Rule |
+|--------|-------|------|
+| `export default async function foo() {}` | `const foo = (): void => {}; export default foo;` | JS-0067 |
+| `{ type: type }` | `{ type }` | JS-0240 |
+| `vi.fn().mockResolvedValue(undefined)` | `vi.fn().mockResolvedValue()` | JS-W1042 |
+| `void someFunction()` | `someFunction()` | JS-0098 |
+| `import * as mod from './x'` | `import { usedFn } from './x'` | JS-C1003 |
+
+## eslint-disable Inline
+
+Single line:
+```ts
+// eslint-disable-next-line <rule> -- <reason>
+```
+
+Multi-line block:
+```ts
+/* eslint-disable <rule> */
+...
+/* eslint-enable <rule> */
+```
+
+## .codacy.yml
+
+```yaml
+---
+exclude_paths:
+  - "dist/**"
+  - "node_modules/**"
+engines:
+  eslint-8:
+    enabled: true
+    disable_rules:
+      - "ESLint8_security_detect-object-injection"
+    exclude_paths:
+      - "__tests__/**"
+```
+
+Note: Codacy YAML requires `---` preamble on line 1 and uses `engines:` not `tools:`.
+
+## .deepsource.toml
+
+```toml
+version = "1"
+
+[analyzers]
+name = "javascript-typescript"
+enabled = true
+
+  [analyzers.meta]
+  max_complexity = "30"
+  skip_doc_coverage = ["test"]
+
+  [analyzers.meta.checks]
+  Biome_lint_correctness_useQwikValidLexicalScope = "off"
+```
+
+## Admin Merge
+
+```bash
+gh pr merge <PR#> --squash --admin --subject "<commit message>"
+```
+
+Only when all functional checks pass but policy tool blocks.
+
+## Common DeepSource Issue Codes
+
+Full mapping across ~12 sessions:
+
+| Code | Severity | Category | Fix |
+|------|----------|----------|-----|
+| JS-0067 | Minor | Anti Pattern | `function` → `const` arrow + export default |
+| JS-0240 | Minor | Anti Pattern | Property shorthand |
+| JS-0339 | Major | Bug Risk | Type narrowing, `?.`, null checks |
+| JS-0357 | Minor | Anti Pattern | Move definition above callers |
+| JS-0098 | Minor | Anti Pattern | Remove `void` keyword |
+| JS-W1042 | Minor | Anti Pattern | Omit `undefined` arg |
+| JS-C1003 | Minor | Anti Pattern | Named imports |
+| R1005 | Minor | Complexity | `.deepsource.toml` or code split |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,7 @@ Do not finish with failing lint, typecheck, tests, build, or quality gate output
 | `shell-script-quality` | Lint and test shell scripts using ShellCheck and BATS. Use w | Quality |
 | `skill-creator` | Create new skills, modify and improve existing skills, and m | Meta |
 | `skill-evaluator` | Reusable skill for evaluating other skills with structure ch | Meta |
+| `static-analysis-suppression` | Suppress false-positive Codacy/DeepSource/ESLint blockers on PRs with code-level, config-level, or admin-merge fixes. Follows decision tree: fix code before suppressing config before admin override. | Quality |
 | `stitch-design` | > | General |
 | `task-decomposition` | Break down complex tasks into atomic, actionable goals with  | Coordination |
 | `test-runner` | Execute tests, analyze results, and diagnose failures across | Quality |


### PR DESCRIPTION
## Summary

Adds `static-analysis-suppression` skill for handling Codacy/DeepSource/ESLint false-positive blockers on PRs.

### What it covers

- **Decision tree**: fix code → suppress config → admin merge (in that order)
- **6 common DeepSource code rewrites** (JS-0067, JS-0240, JS-0339, JS-0357, JS-0098, JS-W1042, JS-C1003, R1005)
- **5 Codacy ESLint codes** (detect-object-injection, no-confusing-void-expression, useImportType, react-hooks/refs, set-state-in-effect)
- **Inline `eslint-disable`** single-line and block patterns
- **Config suppression** via `.codacy.yml` and `.deepsource.toml`
- **Admin merge override** for all-real-checks-pass scenarios

### Files

- `.agents/skills/static-analysis-suppression/SKILL.md` — 142 lines
- `.agents/skills/static-analysis-suppression/evals/evals.json` — 18 test cases
- `.agents/skills/static-analysis-suppression/references/suppression-methods.md` — full code/rule reference
- `.agents/skills/static-analysis-suppression/references/evaluating-skills.md` — eval procedure
- `AGENTS.md` — skill registered in skill table