### PR TITLE
fix(deepsource): correct config with valid cyclomatic_complexity_threshold

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -18,9 +18,13 @@ name = "javascript-typescript"
 enabled = true
 
   [analyzers.meta]
-  max_complexity = "30"
+  cyclomatic_complexity_threshold = "very-high"
   max_functions = "50"
   skip_doc_coverage = ["test"]
+  plugins = ["react"]
+  environment = ["nodejs", "browser"]
+  module_system = "es-modules"
+  dialect = "typescript"
 
   [analyzers.meta.ratings]
     documentation_coverage = "A"
@@ -28,7 +32,3 @@ enabled = true
   [analyzers.meta.checks]
   # Disable Qwik-specific rules (project doesn't use Qwik)
   Biome_lint_correctness_useQwikValidLexicalScope = "off"
-  # void is required by @typescript-eslint/no-floating-promises
-  JS_0098 = "off"
-  # Pre-existing complexity in App.tsx (tracked for refactor)
-  JS_R1005 = "off"


### PR DESCRIPTION
## Summary
- Fix DeepSource JavaScript analyzer config: replace invalid `max_complexity = "30"` with valid `cyclomatic_complexity_threshold = "very-high"`
- Add proper JS/TS analyzer settings: `plugins = ["react"]`, `environment = ["nodejs", "browser"]`, `module_system = "es-modules"`, `dialect = "typescript"`
- Remove unsupported check suppressions (JS_0098, JS_R1005) — DeepSource doesn't support per-check disable via TOML

## Root Cause
DeepSource was failing on main because:
1. `max_complexity = "30"` is not a valid DeepSource config key
2. `JS_0098 = "off"` and `JS_R1005 = "off"` in `[analyzers.meta.checks]` are not recognized by DeepSource
3. Missing proper analyzer settings caused incorrect analysis

## Quality Gate
- [x] Lint: 0 errors
- [x] Typecheck: no errors