### PR TITLE
fix(security): add Zod validation to WebRTC sync channel

### DIFF
--- a/src/lib/sync/peer.ts
+++ b/src/lib/sync/peer.ts
@@ -5,7 +5,7 @@
  * Uses a signaling channel (manual exchange via QR code) to establish connections.
  */
 import { logger } from '../logger';
-import type { SyncSnapshot } from './protocol';
+import { SyncSnapshotSchema, SyncMessageSchema } from './protocol';
 import { createSyncSnapshot, mergeSnapshots } from './protocol';
 import { repository } from '../../db/repository';
 
@@ -112,7 +112,14 @@ export function setupDataChannel(
 
   channel.onmessage = async (event) => {
     try {
-      const msg = JSON.parse(event.data as string) as { type: string; data: unknown };
+      const raw: unknown = JSON.parse(event.data as string);
+      const msgResult = SyncMessageSchema.safeParse(raw);
+      if (!msgResult.success) {
+        logger.warn('Invalid sync message format', msgResult.error);
+        return;
+      }
+      const msg = msgResult.data;
+
       if (msg.type === 'sync-request') {
         peer.state = 'syncing';
         callbacks.onStateChange?.('syncing');
@@ -130,7 +137,14 @@ export function setupDataChannel(
         peer.state = 'syncing';
         callbacks.onStateChange?.('syncing');
 
-        const remoteSnapshot = msg.data as SyncSnapshot;
+        const snapshotResult = SyncSnapshotSchema.safeParse(msg.data);
+        if (!snapshotResult.success) {
+          logger.warn('Invalid sync snapshot from peer', snapshotResult.error);
+          peer.state = 'error';
+          callbacks.onError?.('Invalid data received from peer');
+          return;
+        }
+        const remoteSnapshot = snapshotResult.data;
 
         const localEntities = await repository.getAllEntities();
         const localLinks = await repository.getAllLinks();

--- a/src/lib/sync/peer.ts
+++ b/src/lib/sync/peer.ts
@@ -29,7 +29,7 @@ export interface SyncCallbacks {
   onError?: (error: string) => void;
 }
 
-let deviceId: string = '';
+let deviceId = '';
 function getDeviceId(): string {
   if (!deviceId) {
     deviceId = localStorage.getItem('dks:device-id') ?? crypto.randomUUID();

--- a/src/lib/sync/protocol.ts
+++ b/src/lib/sync/protocol.ts
@@ -6,8 +6,8 @@
  * with conflict resolution by timestamp.
  */
 import { z } from 'zod';
-import type { Entity, Claim, Note, Link } from '../../lib/validation';
-import { EntitySchema, ClaimSchema, NoteSchema } from '../../lib/validation';
+import type { Entity, Claim, Note, Link } from '../validation';
+import { EntitySchema, ClaimSchema, NoteSchema } from '../validation';
 
 export const SyncMessageSchema = z.object({
   type: z.enum(['sync-request', 'sync-data', 'sync-ack']),

--- a/src/lib/sync/protocol.ts
+++ b/src/lib/sync/protocol.ts
@@ -5,7 +5,29 @@
  * Uses a simple snapshot-based approach: full entity/claim/note data exchange
  * with conflict resolution by timestamp.
  */
+import { z } from 'zod';
 import type { Entity, Claim, Note, Link } from '../../lib/validation';
+import { EntitySchema, ClaimSchema, NoteSchema } from '../../lib/validation';
+
+export const SyncMessageSchema = z.object({
+  type: z.enum(['sync-request', 'sync-data', 'sync-ack']),
+  data: z.unknown(),
+});
+
+export const SyncSnapshotSchema = z.object({
+  entities: z.array(EntitySchema),
+  claims: z.array(ClaimSchema),
+  notes: z.array(NoteSchema),
+  links: z.array(z.object({
+    id: z.string().optional(),
+    source_id: z.string(),
+    target_id: z.string(),
+    relation: z.string(),
+    created_at: z.string().optional(),
+  })),
+  timestamp: z.string(),
+  deviceId: z.string(),
+});
 
 export interface SyncSnapshot {
   entities: Entity[];


### PR DESCRIPTION
## Summary
- Add Zod schemas for WebRTC sync messages and snapshots
- Validate all incoming peer data before processing
- Reject malformed snapshots with proper error handling

## Security Issue
The WebRTC sync channel in `src/lib/sync/peer.ts` was accepting arbitrary JSON from peers and casting it directly to `SyncSnapshot` without validation. A malicious peer could send malformed data that could cause crashes or unexpected behavior.

## Changes
- `src/lib/sync/protocol.ts`: Added `SyncMessageSchema` and `SyncSnapshotSchema` using existing Zod schemas
- `src/lib/sync/peer.ts`: Added validation for incoming messages and snapshots

## Quality Gate
- [x] Lint: 0 errors
- [x] Typecheck: no errors
- [x] Tests: 897 passed, 23 skipped