### PR TITLE
chore(codebase): replace console.log/warn/error/debug with logger

### DIFF
--- a/src/features/graph/GraphSyncEvents.tsx
+++ b/src/features/graph/GraphSyncEvents.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type Graph from 'graphology';
 import { useGraphSyncStore } from '../../store/graph-sync-store';
 import type { SharedNode, SharedEdge } from '../../store/graph-sync-types';
+import { logger } from '../../lib/logger';
 
 export const useGraphSyncEvents = (graphRef: { current: Graph | null }) => {
   useEffect(() => {
@@ -29,7 +30,7 @@ export const useGraphSyncEvents = (graphRef: { current: Graph | null }) => {
           if (graph.hasNode(payload.id)) {
             const currentLabel = graph.getNodeAttribute(payload.id, 'label') as string;
             if (currentLabel !== payload.label) {
-              console.warn(`[Sync Conflict] Graph node ${payload.id} has different label. Local: ${currentLabel}, Incoming: ${payload.label}. Applying last-writer wins.`);
+              logger.warn(`[Sync Conflict] Graph node ${payload.id} has different label. Local: ${currentLabel}, Incoming: ${payload.label}. Applying last-writer wins.`);
               graph.mergeNodeAttributes(payload.id, { label: payload.label });
             }
           }

--- a/src/features/mindmap/MindMapView.tsx
+++ b/src/features/mindmap/MindMapView.tsx
@@ -251,7 +251,7 @@ const MindMapView: React.FC<Props> = ({
         } else if (event.type === 'node:update') {
           const el = mindInstance.current?.findEle(payload.id);
           if (el && el.nodeObj.topic !== payload.label) {
-            console.warn(`[Sync Conflict] Mind map node ${payload.id} has different label. Local: ${el.nodeObj.topic}, Incoming: ${payload.label}. Applying last-writer wins.`);
+            logger.warn(`[Sync Conflict] Mind map node ${payload.id} has different label. Local: ${el.nodeObj.topic}, Incoming: ${payload.label}. Applying last-writer wins.`);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- mind-elixir type resolution
             void mindInstance.current?.updateNodeStyle(payload.id); // Refresh
             el.nodeObj.topic = payload.label;

--- a/src/lib/ai/entity-extractor.ts
+++ b/src/lib/ai/entity-extractor.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider } from '../llm/types';
+import { logger } from '../logger';
 
 export const ENTITY_EXTRACTION_PROMPT = `
 Analyze the following note and extract:
@@ -55,7 +56,7 @@ export async function extractEntities(
     const jsonStr = jsonMatch ? jsonMatch[0] : response.content;
     return JSON.parse(jsonStr) as EntityExtractionResult;
   } catch (err) {
-    console.error('Failed to parse entity extraction response', err, response.content);
+    logger.error('Failed to parse entity extraction response', err, response.content);
     return { entities: [], relationships: [] };
   }
 }

--- a/src/lib/llm/anthropic.ts
+++ b/src/lib/llm/anthropic.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider, LLMRequest, LLMResponse, LLMStreamChunk, LLMProviderConfig } from './types';
+import { logger } from '../logger';
 
 const ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
 
@@ -121,7 +122,7 @@ export class AnthropicProvider implements LLMProvider {
             return;
           }
         } catch {
-          console.debug('SSE chunk parse skipped (incomplete or invalid JSON)');
+          logger.debug('SSE chunk parse skipped (incomplete or invalid JSON)');
         }
       }
     }

--- a/src/lib/llm/kilo.ts
+++ b/src/lib/llm/kilo.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider, LLMRequest, LLMResponse, LLMStreamChunk, LLMProviderConfig, OpenAIChatResponse, OpenAIErrorResponse } from './types';
+import { logger } from '../logger';
 
 const KILO_BASE_URL = 'https://api.kilo.ai/api/gateway';
 
@@ -115,7 +116,7 @@ export class KiloGatewayProvider implements LLMProvider {
             yield { content, done: false };
           }
         } catch {
-          console.debug('SSE chunk parse skipped (incomplete or invalid JSON)');
+          logger.debug('SSE chunk parse skipped (incomplete or invalid JSON)');
         }
       }
     }

--- a/src/lib/llm/ollama.ts
+++ b/src/lib/llm/ollama.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider, LLMRequest, LLMResponse, LLMStreamChunk, LLMProviderConfig } from './types';
+import { logger } from '../logger';
 
 const OLLAMA_DEFAULT_BASE_URL = 'http://localhost:11434';
 
@@ -115,7 +116,7 @@ export class OllamaProvider implements LLMProvider {
             return;
           }
         } catch {
-          console.debug('SSE chunk parse skipped (incomplete JSON line)');
+          logger.debug('SSE chunk parse skipped (incomplete JSON line)');
         }
       }
     }

--- a/src/lib/llm/openrouter.ts
+++ b/src/lib/llm/openrouter.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider, LLMRequest, LLMResponse, LLMStreamChunk, LLMProviderConfig, OpenAIChatResponse, OpenAIErrorResponse } from './types';
+import { logger } from '../logger';
 
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
@@ -115,7 +116,7 @@ export class OpenRouterProvider implements LLMProvider {
             yield { content, done: false };
           }
         } catch {
-          console.debug('SSE chunk parse skipped (incomplete or invalid JSON)');
+          logger.debug('SSE chunk parse skipped (incomplete or invalid JSON)');
         }
       }
     }


### PR DESCRIPTION
## Summary
- Replace direct console.log/warn/error/debug calls with the project's logger utility
- Ensures consistent logging format and dev-only debug output

## Changes
| File | Change |
|------|--------|
| `GraphSyncEvents.tsx` | console.warn → logger.warn |
| `MindMapView.tsx` | console.warn → logger.warn |
| `entity-extractor.ts` | console.error → logger.error |
| `openrouter.ts` | console.debug → logger.debug |
| `kilo.ts` | console.debug → logger.debug |
| `anthropic.ts` | console.debug → logger.debug |
| `ollama.ts` | console.debug → logger.debug |

Note: `db-worker.ts` console statements are left as-is since it runs in a Web Worker context where the logger may not be available.

## Quality Gate
- [x] Lint: 0 errors
- [x] Typecheck: no errors